### PR TITLE
NetworkManager, regular partitions & boot timeout

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ YTL Linux installs:
 
 ## What to do if the installation fails
 
- 1. Try again. The installation downloads massive amount of data and there might be shortages. The installation is less robust what comes to the network problems.
+ 1. Try again. The installation downloads massive amount of data and there might be outages. The installation is less robust what comes to the network problems.
  1. Try with a different network (e.g. by sharing a network via your mobile phone). Maybe your ISP blocks or filters data?
  1. Are you using Legacy/BIOS boot? Try enabling SecureBoot instead.
  1. Take some screenshots (again, your mobile phone is your friend here):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,42 @@
+# Installing YTL Linux
+
+YTL Linux installs:
+ * Ubuntu server with Cinnamon desktop environment. Cinnamon was selected
+   as it might be more familiar with Windows users than some other desktop
+   environments.
+ * A metapackage `ytl-linux-customize` installs a tested Oracle VirtualBox
+   version and some smaller tools. It also contains
+ * Users for the school and MEB. However, the MEB account is currently disabled.
+
+## Instructions
+
+ 1. Download [the installation image](https://linux.abitti.fi/ytl-install.iso).
+ 1. Write the image to an USB stick.
+ 1. The installation is silent and it overwrites the storage. Make sure your disks do not contain any valuable data.
+ 1. Connect the server to a wired network. Your network needs to provide network settings from a DHCP server. If your network requires proxy settings or filters traffic you may encounter problems.
+ 1. Boot the server from the USB stick you created earlier.
+ 1. Select "Install YTL Ubuntu Server" by pressing Enter. After this there is no way back.
+ 1. In an early stage of the installation the server checks the USB stick for defected data. Make sure it reports only 1 corrupted file:\
+ `Check finished: errors found in 1 files!`
+ 1. The computer reboots after a successful installation.
+ 1. Log in (`school` / `school`) and change the password: Menu (bottom-left) > Preferences > Account Details > Password.
+ 1. In case your screen resolution is bad try: Menu > Preferences > Display: Normal Graphics On Boot. Finally, reboot the server.
+ 1. Start Naksu to install the virtualised server: Menu > Administration > Naksu.
+
+## What to do if the installation fails
+
+ 1. Try again. The installation downloads massive amount of data and there might be shortages. The installation is less robust what comes to the network problems.
+ 1. Try with a different network (e.g. by sharing a network via your mobile phone). Maybe your ISP blocks or filters data?
+ 1. Are you using Legacy/BIOS boot? Try enabling SecureBoot instead.
+ 1. Take some screenshots (again, your mobile phone is your friend here):
+   * The screen where the installation finished.
+   * Press Alt+F2 > enter command \
+     `cat /var/log/curtin/install.log` \
+     and take a screenshot.
+   * Send these screenshots and your contact information to Abitti support.
+
+## What to do if you want to suggest changes and/or additions
+
+ * Contact Abitti support by email. You'll find the contact information from the [Abitti website](https://abitti.fi).
+ * Open a [GitHub issue](https://github.com/digabi/ytl-linux/issues).
+ * YTL Linux is open source. Make a pull request.

--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ The image can be tested in KVM with something like this:
 - run a virtual KVM machine
 
         kvm -hda test.img -cdrom ytl-install.iso -m 2048
+
+## Debugging failing installations
+
+When installation fails the installer stops and prints a Python traceback or similar
+error log describing the problem. In this case you can open a new console by
+pressing Alt+F2 (Alt+F3...) and study the log files. The most relevant log files
+are:
+ * `/var/log/cloud-init-output.log` Output of the cloud-init part of the installation
+ * `/var/log/cloud-init.log` Log of the cloud-init part of the installation
+ * `/var/log/curtin/install.log` Log of the Curtin part of the installation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The YTL Linux is an Ubuntu environment which installs automatically
 everything you need to run a virtual Abitti server (Oracle VirtualBox and Naksu). The ultimate goals are:
- * Take the pain of updating servers and finding working combinations of software from the schools to the Matriculation Examination Board (Ylioppilastutkintolautakunta YTL in Finnish).
+ * Move the pain of updating servers and finding working combinations of software from the schools to the Matriculation Examination Board (Ylioppilastutkintolautakunta YTL in Finnish).
  * Make the Linux servers more uniform in order to help communication between the schools and the Abitti support in case of trouble.
  * In the long term make it possible to provide remote support during the exams.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# ytl-linux
-An easy-to-install Linux to run virtual exam server (KTP)
+# YTL Linux
 
-This is work in progress.
+The YTL Linux is an Ubuntu environment which installs automatically
+everything you need to run a virtual Abitti server (Oracle VirtualBox and Naksu). The ultimate goals are:
+ * Take the pain of updating servers and finding working combinations of software from the schools to the Matriculation Examination Board (Ylioppilastutkintolautakunta YTL in Finnish).
+ * Make the Linux servers more uniform in order to help communication between the schools and the Abitti support in case of trouble.
+ * In the long term make it possible to provide remote support during the exams.
+
+This is work in progress. If you want to try the latest version please read the
+[installation instructions](INSTALL.md).
 
 ## Building the image
 

--- a/docs/autoinstall-config/user-data
+++ b/docs/autoinstall-config/user-data
@@ -106,3 +106,7 @@ autoinstall:
     - echo "[SeatDefaults]\nuser-session=cinnamon" >/target/etc/lightdm/lightdm.conf.d/cinnamon.conf
     # Disable Cinnamon 3D graphics warning
     - echo "#!/bin/sh\n\nexport CINNAMON_2D=true\n" >/target/etc/profile.d/cinnamon_2d.sh
+    # Use NetworkManager instead of networkd
+    - 'rm -fR /target/etc/netplan/*'
+    - 'echo "network:\n  version: 2\n  renderer: NetworkManager\n" >/target/etc/netplan/01-use-network-manager.yaml'
+    - curtin in-target --target=/target -- netplan apply

--- a/docs/autoinstall-config/user-data
+++ b/docs/autoinstall-config/user-data
@@ -93,7 +93,7 @@ autoinstall:
     # install Vagrant
     - wget -O /target/tmp/vagrant.deb -c https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.deb
     - curtin in-target --target=/target -- apt install /tmp/vagrant.deb
-    # add user for the school (password: school)
+    # add user for MEB
     - curtin in-target --target=/target -- useradd -p $1$wIiwKtrF$0Y3YOfuHMSIdsg.69sIWw0 -U -m meb
     - curtin in-target --target=/target -- usermod -c "Matriculation Examination Board" -s /bin/false -L -e 1 meb
     - curtin in-target --target=/target -- addgroup meb sudo

--- a/docs/autoinstall-config/user-data
+++ b/docs/autoinstall-config/user-data
@@ -73,7 +73,7 @@ autoinstall:
     - ytl-linux-customize
   storage:
       layout:
-          name: lvm
+          name: direct
   identity:
       hostname: ktp
       username: school

--- a/docs/autoinstall-config/user-data
+++ b/docs/autoinstall-config/user-data
@@ -90,9 +90,6 @@ autoinstall:
     - sed -i 's/GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/' /target/etc/default/grub
     # update grub settings
     - curtin in-target --target=/target -- update-grub
-    # install Vagrant
-    - wget -O /target/tmp/vagrant.deb -c https://releases.hashicorp.com/vagrant/2.2.10/vagrant_2.2.10_x86_64.deb
-    - curtin in-target --target=/target -- apt install /tmp/vagrant.deb
     # add user for MEB
     - curtin in-target --target=/target -- useradd -p $1$wIiwKtrF$0Y3YOfuHMSIdsg.69sIWw0 -U -m meb
     - curtin in-target --target=/target -- usermod -c "Matriculation Examination Board" -s /bin/false -L -e 1 meb

--- a/mangle-image
+++ b/mangle-image
@@ -24,6 +24,9 @@ sed -i '/txt\.cfg/ iinclude ytl.cfg' "$WORKDIR"/isolinux/menu.cfg
 # disable the default boot to live installation mode
 sed -i 's/^ui /# ui/' "$WORKDIR"/isolinux/isolinux.cfg
 
+# disable timeout to avoid installation loops and accidents
+sed -i 's/timeout [[:digit:]]\+/timeout 0/' "$WORKDIR"/isolinux/*.cfg
+
 #########################################
 # Step 2: UEFI boot mode / GRUB
 #########################################
@@ -32,5 +35,8 @@ sed -i '/"Install Ubuntu Server"/iINCLUDE_YTL_MENU' "$WORKDIR"/boot/grub/grub.cf
 sed -i '/INCLUDE_YTL_MENU/r templates/ytl-grub.cfg' "$WORKDIR"/boot/grub/grub.cfg
 sed -i '/INCLUDE_YTL_MENU/d' "$WORKDIR"/boot/grub/grub.cfg
 sed -i "s|##AUTOINSTALL_URL##|$AUTOINSTALL_URL|" "$WORKDIR"/boot/grub/grub.cfg
+
+# disable timeout to avoid installation loops and accidents
+sed -i 's/timeout=[[:digit:]]\+/timeout=-1/' "$WORKDIR"/boot/grub/grub.cfg
 
 # All done!

--- a/ytl-linux-customize/Makefile
+++ b/ytl-linux-customize/Makefile
@@ -1,7 +1,7 @@
-VERSION := "1.0.1"
+VERSION := "1.0.2"
 
 # Dependencies which are not related to any code in the
-DEPENDENCIES_META := --depends virtualbox-6.1
+DEPENDENCIES_META := --depends virtualbox-6.1 --depends ethtool --depends exfat-fuse --depends update-manager
 
 DEPENDENCIES_NAKSU := --depends wget --depends zenity
 DEPENDENCIES_YTL-GRUB-SAFE-GRAPHICS := --depends policykit-1


### PR DESCRIPTION
* Käytä asennuksen NetworkManageria, jotta käyttäjän on helpompi hallita verkkoasetuksia
* Älä asenna LVM:ää vaan normaalit levyosiot, jotta ongelmien selvittely olisi helppoa
* Älä asenna Vagrantia, koska Naksu 2 ei enää käytä sitä
* Estä asennuksen käynnistys automaattisesti
