### PR TITLE
Do not wait for network on boot

### DIFF
--- a/.github/workflows/reprepro.yml
+++ b/.github/workflows/reprepro.yml
@@ -4,6 +4,7 @@ on:
     paths:
         - 'debs/**'
         - 'ytl-linux-customize/**'
+        - 'ytl-linux-purge-deb/**'
         - '.github/workflows/reprepro.yml'
   workflow_dispatch:
 
@@ -17,9 +18,12 @@ jobs:
             sudo gem install --no-document fpm
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Build deb packages
+      - name: Build ytl-linux-customize deb package
         run: |
             make -C ytl-linux-customize deb
+      - name: Build ytl-linux-purge-deb deb package
+        run: |
+            make -C ytl-linux-purge-deb deb
       - name: Build repository
         env:
             SKEY: ${{ secrets.YTL_LINUX_PACKAGE_SIGNING_PRIVATE_KEY }}
@@ -31,7 +35,7 @@ jobs:
             echo "Signing with key 0x$keyid"
             echo "SignWith: 0x$keyid" >> reprepro/conf/distributions
             for dir in debs/ ytl-linux-customize/; do [ -d $dir ] || mkdir $dir; done
-            find debs/ ytl-linux-customize/ -name '*.deb' | while read deb; do echo $deb; reprepro -b reprepro includedeb ytl-linux $deb; done
+            find debs/ ytl-linux-customize/ ytl-linux-purge-deb/ -name '*.deb' | while read deb; do echo $deb; reprepro -b reprepro includedeb ytl-linux $deb; done
             # also make signing key available on the web site
             echo "$SPUBKEY" > apt-signing-key.pub
       - name: Look up AWS credentials

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 ytl-linux-customize/*.deb
 ytl-linux-customize/deb-root/
 ytl-linux-customize/deb-scripts/
+
+ytl-linux-purge-deb/*.deb
+ytl-linux-purge-deb/deb-root/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 ubuntu:jammy
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install wget fdisk libarchive-tools xorriso cd-boot-images-amd64
-RUN mkdir /app && wget -O /app/ubuntu.iso https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso
+RUN mkdir /app && wget -O /app/ubuntu.iso https://releases.ubuntu.com/jammy/ubuntu-22.04.4-live-server-amd64.iso
 COPY build-ytl-image /app/
 COPY mangle-image /app/
 COPY templates/ /app/templates/

--- a/build-ytl-image
+++ b/build-ytl-image
@@ -9,7 +9,7 @@ set -e
 # Configurable settings:
 
 # location of the original Ubuntu installation ISO image
-DOWNLOAD_URL=https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso
+DOWNLOAD_URL=https://releases.ubuntu.com/jammy/ubuntu-22.04.4-live-server-amd64.iso
 
 # location where the clients should download the installation configuration
 # (exported for the benefit of mangle-image below)

--- a/docs/autoinstall-config-22/user-data
+++ b/docs/autoinstall-config-22/user-data
@@ -164,6 +164,7 @@ autoinstall:
     - 'echo "network:\n  version: 2\n  renderer: NetworkManager\n" >/target/etc/netplan/01-use-network-manager.yaml'
     - 'chmod 0600 /target/etc/netplan/01-use-network-manager.yaml'
     - curtin in-target --target=/target -- netplan apply
+    - curtin in-target --target=/target -- systemctl mask systemd-networkd-wait-online.service
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
     - sed -i 's/APT::Periodic::Unattended-Upgrade .*/APT::Periodic::Unattended-Upgrade "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades

--- a/docs/autoinstall-config-22/user-data
+++ b/docs/autoinstall-config-22/user-data
@@ -162,6 +162,7 @@ autoinstall:
     # Use NetworkManager instead of networkd
     - 'rm -fR /target/etc/netplan/*'
     - 'echo "network:\n  version: 2\n  renderer: NetworkManager\n" >/target/etc/netplan/01-use-network-manager.yaml'
+    - 'chmod 0600 /target/etc/netplan/01-use-network-manager.yaml'
     - curtin in-target --target=/target -- netplan apply
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades

--- a/docs/autoinstall-config-22/user-data
+++ b/docs/autoinstall-config-22/user-data
@@ -122,6 +122,7 @@ autoinstall:
   packages:
     - cinnamon-core
     - ytl-linux-customize
+    - ytl-linux-purge-deb
     - snapd
   snaps:
     - name: firefox
@@ -167,6 +168,9 @@ autoinstall:
     # Disable all network waits
     - curtin in-target --target=/target -- systemctl mask NetworkManager-wait-online.service
     - curtin in-target --target=/target -- systemctl mask systemd-networkd-wait-online.service
+    # Remove some unnecessary packages on next boot
+    - echo open-iscsi >>/target/etc/ytl-linux-purge-deb.conf
+    - echo networkd-dispatcher >>/target/etc/ytl-linux-purge-deb.conf
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
     - sed -i 's/APT::Periodic::Unattended-Upgrade .*/APT::Periodic::Unattended-Upgrade "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades

--- a/docs/autoinstall-config-22/user-data
+++ b/docs/autoinstall-config-22/user-data
@@ -164,6 +164,8 @@ autoinstall:
     - 'echo "network:\n  version: 2\n  renderer: NetworkManager\n" >/target/etc/netplan/01-use-network-manager.yaml'
     - 'chmod 0600 /target/etc/netplan/01-use-network-manager.yaml'
     - curtin in-target --target=/target -- netplan apply
+    # Disable all network waits
+    - curtin in-target --target=/target -- systemctl mask NetworkManager-wait-online.service
     - curtin in-target --target=/target -- systemctl mask systemd-networkd-wait-online.service
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades

--- a/ytl-linux-purge-deb/Makefile
+++ b/ytl-linux-purge-deb/Makefile
@@ -1,0 +1,32 @@
+NAME := ytl-linux-purge-deb
+VERSION := "0.0.1"
+
+DEPENDENCIES := --depends debianutils --depends cron --depends bash --depends bsdutils
+DEB_ROOT := deb-root
+
+deb:
+	if [ -d $(DEB_ROOT) ]; then rm -fR $(DEB_ROOT)/; fi
+	if [ -f $(NAME)_$(VERSION)_amd64.deb ]; then rm $(NAME)_$(VERSION)_amd64.deb; fi
+
+	# Package documentation
+	mkdir -p $(DEB_ROOT)/usr/local/share/doc/$(NAME)
+
+	mkdir -p $(DEB_ROOT)/etc/cron.d
+	cp cronjob $(DEB_ROOT)/etc/cron.d/$(NAME)
+	chmod 0644 $(DEB_ROOT)/etc/cron.d/$(NAME)
+
+	mkdir -p $(DEB_ROOT)/usr/local/sbin
+	cp ytl-linux-purge-deb $(DEB_ROOT)/usr/local/sbin/ytl-linux-purge-deb
+	chmod 755 $(DEB_ROOT)/usr/local/sbin/ytl-linux-purge-deb
+
+	mkdir -p $(DEB_ROOT)/etc
+	cp ytl-linux-purge-deb.conf $(DEB_ROOT)/etc/ytl-linux-purge-deb.conf
+	chmod 644 $(DEB_ROOT)/etc/ytl-linux-purge-deb.conf
+
+	fpm -C $(DEB_ROOT)/ -s dir --name $(NAME) --architecture native -t deb --version "$(VERSION)" \
+		--description "Script to remove named deb packages if they are installed" \
+		--maintainer "abitti@ylioppilastutkinto.fi" \
+		--vendor "Matriculation Examination Board" \
+		--url "https://github.com/digabi/ytl-linux" \
+		$(DEPENDENCIES) \
+		.

--- a/ytl-linux-purge-deb/cronjob
+++ b/ytl-linux-purge-deb/cronjob
@@ -1,0 +1,5 @@
+# /etc/cron.d/cron-reboot: run scripts on boot
+
+SHELL=/bin/sh
+
+@reboot root    /usr/local/sbin/ytl-linux-purge-deb

--- a/ytl-linux-purge-deb/ytl-linux-purge-deb
+++ b/ytl-linux-purge-deb/ytl-linux-purge-deb
@@ -1,0 +1,37 @@
+#!/usr/bin/bash
+
+TAG=ytl-linux-purge-deb
+
+is_installed () {
+    package=$1
+    echo "Checking if package $package is installed"
+    status=`dpkg-query -W --showformat='${Status}\n' $package 2>/dev/null |grep "install ok installed"`
+    if [ $? -gt 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+purge_package () {
+    package=$1
+    logger --tag=$TAG "Purging package $package"
+    apt-get --yes purge $package
+}
+
+while IFS="" read -r line || [ -n "$line" ]
+do
+    package_name=`echo $line | sed 's|\s||g'`
+    if [ -z "$package_name" ]; then
+        continue
+    fi
+
+    if [[ "$package_name" =~ "#".* ]]; then
+        continue
+    fi
+
+    is_installed $package_name
+    if [ $? -gt 0 ]; then
+        purge_package $package_name
+    fi
+done < /etc/ytl-linux-purge-deb.conf

--- a/ytl-linux-purge-deb/ytl-linux-purge-deb.conf
+++ b/ytl-linux-purge-deb/ytl-linux-purge-deb.conf
@@ -1,0 +1,7 @@
+# This file lists .deb packages which ytl-linux-purge-deb tries to purge on
+# boot, if detected.
+#
+# This file should contain package names to remove (think `apt purge [linecontent]`).
+# One package name per line.
+#
+# Files starting with # are ignored. Empty lines are ignored.


### PR DESCRIPTION
Typically the Abitti server is itself the DHCP server for Abitti clients. In the exam network there is no DHCP servers and the regular Ubuntu Server requires response from DHCP to boot. This pull request makes following changes:
* Remove `open-iscsi` package which requires network access on boot.
* Masks (makes ineffective) two systemd targets waiting network on boot.
* Additional script `ytl-linux-purge-deb` executed by cron on boot. The script removes named deb packages on boot, if installed.
