### PR TITLE
Add ethtool dependency for digabi2

### DIFF
--- a/debs/naksu2_2.1.3_amd64.deb
+++ b/debs/naksu2_2.1.3_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de6512bff1d88ed48365c5507e180d601dc78d921544d0adf02082c4f46a6e8f
-size 86674302

--- a/debs/naksu2_2.1.4_amd64.deb
+++ b/debs/naksu2_2.1.4_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43194d7e45b6e2783fa91d24face4fa2199a0918773bf7adf32d90153743cb2a
+size 86668786

--- a/ytl-linux-digabi2/Makefile
+++ b/ytl-linux-digabi2/Makefile
@@ -1,7 +1,7 @@
 NAME := ytl-linux-digabi2
 VERSION := "0.0.1"
 
-DEPENDENCIES := --depends naksu2 --depends libnotify4 --depends libnss3 --depends xdg-utils --depends libasound2 --depends docker-ce --depends docker-ce-cli
+DEPENDENCIES := --depends naksu2 --depends libnotify4 --depends libnss3 --depends xdg-utils --depends libasound2 --depends docker-ce --depends docker-ce-cli --depends ethtool
 DEB_ROOT := deb-root
 
 deb:

--- a/ytl-linux-digabi2/Makefile
+++ b/ytl-linux-digabi2/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2
-VERSION := "0.0.1"
+VERSION := "0.0.2"
 
 DEPENDENCIES := --depends naksu2 --depends libnotify4 --depends libnss3 --depends xdg-utils --depends libasound2 --depends docker-ce --depends docker-ce-cli --depends ethtool
 DEB_ROOT := deb-root


### PR DESCRIPTION
Liittyy: https://github.com/digabi/naksu2/pull/32

Verkkolaitteen nopeuden tunnistus Naksun seuraavassa versiossa vaatii ethtoolin, joten varmistetaan että se on saatavilla.