### PR TITLE
Add flow for updating Naksu 2

### DIFF
--- a/.github/workflows/reprepro.yml
+++ b/.github/workflows/reprepro.yml
@@ -65,3 +65,10 @@ jobs:
           aws s3 sync --cache-control no-store reprepro/pool  s3://ytl-linux/deb/pool
           aws s3 sync --cache-control no-store reprepro/dists s3://ytl-linux/deb/dists
           aws s3 cp --cache-control no-store apt-signing-key.pub s3://ytl-linux/
+      - name: Update Naksu 2 latest version
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          export NAKSU_DEB=$(find debs -name 'naksu2*.deb')
+          export VERSION=$(dpkg-deb -f "$NAKSU_DEB" Version)
+          echo '{ "version": "$VERSION" }' | envsubst > naksu2-latest-version.json
+          aws s3 cp --cache-control no-store naksu2-latest-version.json s3://ytl-linux/meta/

--- a/.github/workflows/reprepro.yml
+++ b/.github/workflows/reprepro.yml
@@ -1,4 +1,4 @@
-name: update Debian repository
+name: Update Debian repository
 on:
   push:
     paths:
@@ -53,12 +53,14 @@ jobs:
             # also make signing key available on the web site
             echo "$SPUBKEY" > apt-signing-key.pub
       - name: Look up AWS credentials
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-north-1
       - name: Copy repository to AWS S3
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           aws s3 sync --cache-control no-store reprepro/pool  s3://ytl-linux/deb/pool
           aws s3 sync --cache-control no-store reprepro/dists s3://ytl-linux/deb/dists

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ NkP7g8coWb57JQj63AgO9ukfqYuR4XqQHW3ga6U4cKhPUU1ChE5H
 
 Run `sudo apt update` and make sure the legacy keyring warning has disappeared.
 
+## Naksu 2
+
+Run `scripts/update-naksu2.sh` to download the latest version of the Naksu 2 deb from GitHub Releases.
+
 ## Building the image
 
 ### Building the image locally

--- a/scripts/update-naksu2.sh
+++ b/scripts/update-naksu2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+cd debs
+
+rm -f naksu2*.deb
+gh release download --repo digabi/naksu2 --pattern '*.deb'


### PR DESCRIPTION
Naksu 2 rinnakkais-PR: https://github.com/digabi/naksu2/pull/44

Johdonmukaistettu Naksu 2:n päivittämistä YTL-Linuxissa ja automatisoitu siitä suurin osa. Uusimman version lataaminen S3:een vaaditaan, jotta Naksu voisi tietää, mikä uusin saatavilla oleva versio on.

Muutettu myös deployta siten, että pakettirepoon viedään asiat vain main-haarasta, ei sivuhaaroilta. Eilen meillä oli rikkinäistä koodia saatavilla vajaan tunnin ajan tämän takia.