### PR TITLE
Update name of env var INSTALL_IMAGE to Makefile target docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ docker:
 	-docker rm ytl-linux-builder
 	docker build -t ytl-linux-build-img:latest -f Dockerfile.build .
 	docker run -w /app --name ytl-linux-builder ytl-linux-build-img:latest ./build-ytl-image
-	docker cp ytl-linux-builder:/app/$(IMAGE) .
+	docker cp ytl-linux-builder:/app/$(INSTALL_IMAGE) .
 
 create-vb-vm:
 	-VBoxManage controlvm "$(VM_NAME)" poweroff


### PR DESCRIPTION
Environment variable IMAGE was renamed to INSTALL_IMAGE in 207e4e2 but was never updated to the docker target in the Makefile. This causes the command `make docker` to fail copying the built `ytl-install-24.iso` to the working directory.