### PR TITLE
Try to convince to Windows clients that the network has internet

### DIFF
--- a/ytl-linux-digabi2-examnet/Makefile
+++ b/ytl-linux-digabi2-examnet/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2-examnet
-VERSION := "0.0.2"
+VERSION := "0.0.3"
 
 DEPENDENCIES := \
 	--depends apt \

--- a/ytl-linux-digabi2-examnet/Makefile
+++ b/ytl-linux-digabi2-examnet/Makefile
@@ -15,7 +15,17 @@ deb:
 	# Script file
 	mkdir -p $(DEB_ROOT)/usr/local/sbin/
 	cp ytl-linux-digabi2-examnet $(DEB_ROOT)/usr/local/sbin/
+
+	# NCSI server
+	cp ytl-linux-digabi2-ncsi-srv $(DEB_ROOT)/usr/local/sbin/
+	
 	chmod 755 $(DEB_ROOT)/usr/local/sbin/*
+
+	# systemd unit file
+	mkdir -p $(DEB_ROOT)/etc/systemd/system/
+	cp ytl-linux-digabi2-ncsi.service $(DEB_ROOT)/etc/systemd/system/
+
+	chmod 644 $(DEB_ROOT)/etc/systemd/system/*
 
 	# Package documentation
 	mkdir -p $(DEB_ROOT)/usr/local/share/doc/$(NAME)
@@ -27,4 +37,6 @@ deb:
 		 --vendor "Matriculation Examination Board" \
 		 --url "https://github.com/digabi/ytl-linux" \
 		 $(DEPENDENCIES) \
+		 --after-install after-install.sh \
+		 --before-remove before-remove.sh \
 		.

--- a/ytl-linux-digabi2-examnet/Makefile
+++ b/ytl-linux-digabi2-examnet/Makefile
@@ -15,6 +15,10 @@ deb:
 	# Script file
 	mkdir -p $(DEB_ROOT)/usr/local/sbin/
 	cp ytl-linux-digabi2-examnet $(DEB_ROOT)/usr/local/sbin/
+	
+	# Config templates
+	mkdir -p ${DEB_ROOT}/etc/ytl-linux-digabi2-examnet/templates/
+	cp templates/* ${DEB_ROOT}/etc/ytl-linux-digabi2-examnet/templates
 
 	# NCSI server
 	cp ytl-linux-digabi2-ncsi-srv $(DEB_ROOT)/usr/local/sbin/

--- a/ytl-linux-digabi2-examnet/after-install.sh
+++ b/ytl-linux-digabi2-examnet/after-install.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+systemctl daemon-reload
+systemctl enable ytl-linux-digabi2-ncsi
+systemctl start ytl-linux-digabi2-ncsi

--- a/ytl-linux-digabi2-examnet/before-remove.sh
+++ b/ytl-linux-digabi2-examnet/before-remove.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+systemctl stop ytl-linux-digabi2-ncsi
+systemctl disable ytl-linux-digabi2-ncsi
+systemctl daemon-reload

--- a/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -1,0 +1,4 @@
+resolv-file=/etc/resolv.conf
+interface=${NET_DEVICE_LAN}
+dhcp-range=${IP_LAN_PREFIX}${SERVER_NUMBER}.10,${IP_LAN_PREFIX}${SERVER_NUMBER}.254,255.255.0.0,1h
+host-record=dns.msftncsi.com,www.msftncsi.com,www.msftconnecttest.com,ipv6.msftconnecttest.com,${IP_LAN_PREFIX}${SERVER_NUMBER}.1

--- a/ytl-linux-digabi2-examnet/templates/resolved.conf.template
+++ b/ytl-linux-digabi2-examnet/templates/resolved.conf.template
@@ -1,0 +1,2 @@
+[Resolve]
+DNSStubListener=no

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -25,10 +25,13 @@ readonly PARAM_SERVER_NUMBER=$3
 
 readonly NETWORK_DEVICE_FILTER_RE="^docker|^br|^veth|^lo$"
 
+readonly PATH_TEMPLATES=/etc/ytl-linux-digabi2-examnet/templates
 readonly PATH_RESOLVED=/etc/systemd/resolved.conf.d
 readonly PATH_RESOLVED_CONF=$PATH_RESOLVED/ytl-linux.conf
+readonly PATH_RESOLVED_CONF_TEMPLATE=$PATH_TEMPLATES/resolved.conf.template
 readonly PATH_DNSMASQ=/etc/dnsmasq.d
 readonly PATH_DNSMASQ_CONF=$PATH_DNSMASQ/ytl-linux.conf
+readonly PATH_DNSMASQ_CONF_TEMPLATE=$PATH_TEMPLATES/dnsmasq.conf.template
 
 readonly BIN_ECHO=/usr/bin/echo
 readonly BIN_TR=/usr/bin/tr
@@ -344,6 +347,9 @@ fi
 debug "NET_DEVICE_WAN: $NET_DEVICE_WAN"
 debug "NET_DEVICE_LAN: $NET_DEVICE_LAN"
 
+export NET_DEVICE_WAN
+export NET_DEVICE_LAN
+
 check_network_device_names "$NET_DEVICE_WAN" "$NET_DEVICE_LAN"
 
 IP_WAN=$(get_ipv4_address "$NET_DEVICE_WAN")
@@ -373,16 +379,15 @@ debug "IP_WAN: $IP_WAN"
 debug "IP_LAN: $IP_LAN"
 debug "SERVER_NUMBER: $SERVER_NUMBER"
 
+export IP_WAN
+export IP_LAN
+export SERVER_NUMBER
+
 IP_LAN_PREFIX=$(get_lan_ip_prefix "$IP_WAN")
-readonly IP_LAN_PREFIX
+export IP_LAN_PREFIX
 
-write_file $PATH_RESOLVED_CONF "[Resolve]\nDNSStubListener=no"
-
-write_file $PATH_DNSMASQ_CONF "resolv-file=/etc/resolv.conf
-interface=$NET_DEVICE_LAN
-dhcp-range=${IP_LAN_PREFIX}${SERVER_NUMBER}.10,${IP_LAN_PREFIX}${SERVER_NUMBER}.254,255.255.0.0,1h
-host-record=dns.msftncsi.com,www.msftncsi.com,www.msftconnecttest.com,ipv6.msftconnecttest.com,${IP_LAN_PREFIX}${SERVER_NUMBER}.1
-"
+write_file $PATH_RESOLVED_CONF "$(envsubst < $PATH_RESOLVED_CONF_TEMPLATE)"
+write_file $PATH_DNSMASQ_CONF "$(envsubst < $PATH_DNSMASQ_CONF_TEMPLATE)"
 
 configure_networkmanager "yo-$NET_DEVICE_LAN" "$NET_DEVICE_LAN" "${IP_LAN_PREFIX}${SERVER_NUMBER}.1/16"
 

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -381,7 +381,7 @@ write_file $PATH_RESOLVED_CONF "[Resolve]\nDNSStubListener=no"
 write_file $PATH_DNSMASQ_CONF "resolv-file=/etc/resolv.conf
 interface=$NET_DEVICE_LAN
 dhcp-range=${IP_LAN_PREFIX}${SERVER_NUMBER}.10,${IP_LAN_PREFIX}${SERVER_NUMBER}.254,255.255.0.0,1h
-host-record=dns.msftncsi.com,www.msftncsi.com,${IP_LAN_PREFIX}${SERVER_NUMBER}.1
+host-record=dns.msftncsi.com,www.msftncsi.com,www.msftconnecttest.com,ipv6.msftconnecttest.com,${IP_LAN_PREFIX}${SERVER_NUMBER}.1
 "
 
 configure_networkmanager "yo-$NET_DEVICE_LAN" "$NET_DEVICE_LAN" "${IP_LAN_PREFIX}${SERVER_NUMBER}.1/16"

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -381,6 +381,7 @@ write_file $PATH_RESOLVED_CONF "[Resolve]\nDNSStubListener=no"
 write_file $PATH_DNSMASQ_CONF "resolv-file=/etc/resolv.conf
 interface=$NET_DEVICE_LAN
 dhcp-range=${IP_LAN_PREFIX}${SERVER_NUMBER}.10,${IP_LAN_PREFIX}${SERVER_NUMBER}.254,255.255.0.0,1h
+host-record=dns.msftncsi.com,www.msftncsi.com,${IP_LAN_PREFIX}${SERVER_NUMBER}.1
 "
 
 configure_networkmanager "yo-$NET_DEVICE_LAN" "$NET_DEVICE_LAN" "${IP_LAN_PREFIX}${SERVER_NUMBER}.1/16"

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi-srv
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi-srv
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'Microsoft NCSI\n')
+
+def run(server_class=HTTPServer, handler_class=SimpleHTTPRequestHandler, port=80):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f'Starting httpd on port {port}...')
+    httpd.serve_forever()
+
+if __name__ == "__main__":
+    run()

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi-srv
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi-srv
@@ -7,7 +7,11 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-type', 'text/plain')
         self.end_headers()
-        self.wfile.write(b'Microsoft NCSI\n')
+
+        if self.path == '/ncsi.txt':
+          self.wfile.write(b'Microsoft NCSI\n')
+        elif self.path == '/connecttest.txt':
+          self.wfile.write(b'Microsoft Connect Test')
 
 def run(server_class=HTTPServer, handler_class=SimpleHTTPRequestHandler, port=80):
     server_address = ('', port)

--- a/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi.service
+++ b/ytl-linux-digabi2-examnet/ytl-linux-digabi2-ncsi.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Digabi 2 HTTPD/NCSI Server
+
+[Service]
+ExecStart=/usr/bin/python3 /usr/local/sbin/ytl-linux-digabi2-ncsi-srv
+WorkingDirectory=/tmp
+StandardOutput=append:/dev/null
+StandardError=append:/dev/null
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This realises a small Python3 httpd server running on port 80. It also adds DNS records to dnsmasq to fullfill following requirements:

The following list describes how NCSI might communicate with a Web site to determine whether a network has Internet connectivity:
1. A request for DNS name resolution of dns.msftncsi.com
1. A HTTP request for http://www.msftncsi.com/ncsi.txt returning 200 OK and the text Microsoft NCSI