### PR TITLE
Install Naksu 2 and examnet setup tool automatically

### DIFF
--- a/ytl-linux-customize-24/Makefile
+++ b/ytl-linux-customize-24/Makefile
@@ -1,8 +1,8 @@
-VERSION := 1.0.0
+VERSION := 1.0.1
 
 # Dependencies which are not related to any code in the
 DEPENDENCIES_META := --depends virtualbox-7.1 --depends ethtool --depends exfat-fuse --depends update-manager --depends gnome-icon-theme \
-	--depends dconf-cli --depends ytl-linux-cpu-governor
+	--depends dconf-cli --depends ytl-linux-cpu-governor --depends ytl-linux-digabi2 --depends ytl-linux-digabi2-examnet
 RECOMMENDS_META := --deb-recommends digabi-usb-monster
 
 DEPENDENCIES_NAKSU := --depends wget --depends zenity


### PR DESCRIPTION
Install these applications to make Abitti 2 installation easier by avoiding manual steps.