### PR TITLE
Revert automatic installation of Naksu 2

### DIFF
--- a/ytl-linux-customize-24/Makefile
+++ b/ytl-linux-customize-24/Makefile
@@ -1,8 +1,8 @@
-VERSION := 1.0.1
+VERSION := 1.0.2
 
 # Dependencies which are not related to any code in the
 DEPENDENCIES_META := --depends virtualbox-7.1 --depends ethtool --depends exfat-fuse --depends update-manager --depends gnome-icon-theme \
-	--depends dconf-cli --depends ytl-linux-cpu-governor --depends ytl-linux-digabi2 --depends ytl-linux-digabi2-examnet
+	--depends dconf-cli --depends ytl-linux-cpu-governor
 RECOMMENDS_META := --deb-recommends digabi-usb-monster
 
 DEPENDENCIES_NAKSU := --depends wget --depends zenity


### PR DESCRIPTION
It appears that there are some dependencies missing for added packages
 * ytl-linux-digabi2
 * ytl-linux-digabi2-examnet

Removed these dependencies for now.