### PR TITLE
Remember discovered friendly names even when servers are offline

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/discovery/justfile
+++ b/packages/ytl-linux-digabi2-examnet/discovery/justfile
@@ -22,7 +22,8 @@ start prod-mode="false" only-to-console="false": generate-dev-conf
             "isProd": {{ prod-mode }},
             "ktpDomains": $(jq -Rcs '[. | split("\n") | .[] | match("host-record=(.+),.+").captures[0].string]' "$PATH_DNSMASQ_STATIC_DNS_CONF"),
             "dnsmasqConfigOutputFile": "$PATH_DNSMASQ_KTP_ALIASES_CONF",
-            "ports": {"discovery": $DISCOVERY_PORT}
+            "ports": {"discovery": $DISCOVERY_PORT},
+            "dbPath": "devconf/discovery.db"
         }
     }
     EOF

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/config.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/config.ts
@@ -6,7 +6,8 @@ export const ConfigSchema = z.object({
   dnsmasqConfigOutputFile: z.string(),
   ports: z.object({
     discovery: z.int().gte(1).lte(0xffff),
-  })
+  }),
+  dbPath: z.string()
 })
 
 export type Config = z.output<typeof ConfigSchema>

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/db.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/db.ts
@@ -1,0 +1,56 @@
+import { DatabaseSync } from 'node:sqlite'
+import { Config } from './config.ts'
+import { DiscoveredKTP } from './discovery.ts'
+import logger from './logger.ts'
+
+let db: DatabaseSync
+
+export function init(config: Config) {
+  db = new DatabaseSync(config.dbPath)
+  create()
+}
+
+export function create() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ktp_friendly_names (
+      address TEXT PRIMARY KEY,
+      target TEXT NOT NULL,
+      alias TEXT NOT NULL,
+      last_seen DATETIME NOT NULL
+    )
+  `)
+}
+
+export function reset() {
+  db.exec(`DROP TABLE IF EXISTS ktp_friendly_names`)
+  create()
+}
+
+export function upsertFriendlyNames(result: DiscoveredKTP[]) {
+  logger.info(`Upserting discovered KTP friendly names to DB`)
+
+  for (const ktp of result) {
+    logger.debug(`Upserting ${ktp.address} friendly name ${ktp.alias} => ${ktp.target} to DB`)
+
+    db.prepare(
+      `
+      INSERT INTO ktp_friendly_names (address, target, alias, last_seen) VALUES (?, ?, ?, datetime('now', 'subsec'))
+      ON CONFLICT (address) DO UPDATE SET target = excluded.target, alias = excluded.alias, last_seen = excluded.last_seen
+    `
+    ).run(ktp.address, ktp.target, ktp.alias)
+  }
+}
+
+export function getFriendlyNames(): DiscoveredKTP[] {
+  return db
+    .prepare(`SELECT address, target, alias, last_seen FROM ktp_friendly_names ORDER BY address `)
+    .all()
+    .map(
+      ({ address, target, alias }) =>
+        ({
+          address,
+          target,
+          alias
+        }) as DiscoveredKTP
+    )
+}

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/discovery.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/discovery.ts
@@ -3,6 +3,7 @@ import { z } from '@zod/zod/v4-mini'
 import logger from './logger.ts'
 import { Config } from './config.ts'
 import { DISCOVERY_PATH } from './constants.ts'
+import { sortByKTPNumber } from './util.ts'
 
 export const DiscoveryResponseSchema = z.object({
   target: z.string(),
@@ -11,16 +12,18 @@ export const DiscoveryResponseSchema = z.object({
 
 export type DiscoveryResponse = z.infer<typeof DiscoveryResponseSchema>
 
-export interface DiscoveredKTP {
-  address: string
-  target: string
-  alias: string
-}
+export const DiscoveredKTPSchema = z.object({
+  address: z.string(),
+  target: z.string(),
+  alias: z.string()
+})
+
+export type DiscoveredKTP = z.infer<typeof DiscoveredKTPSchema>
 
 export async function fetchFromDiscoveryEndpoint(ktpDomain: string, config: Config) {
   const discoveryUrl = `https://${ktpDomain}:${config.ports.discovery}${DISCOVERY_PATH}`
   logger.debug(`Asking ${ktpDomain} for alias using URL ${discoveryUrl}`)
-  
+
   return await fetch(discoveryUrl, {
     signal: AbortSignal.timeout(1000)
   })
@@ -32,7 +35,10 @@ export async function discoverFriendlyNamesInNetwork(
 ): Promise<DiscoveredKTP[]> {
   const discovered: DiscoveredKTP[] = []
 
-  for (const ktpDomain of config.ktpDomains) {
+  // Sort the domains so that the logs make a bit more sense, since the certificate SANs are sorted by "natural order" (i.e. 1, 10, 11, ... 2, 20, 21, ...) and not KTP number order
+  const ktpDomains = config.ktpDomains.toSorted(sortByKTPNumber)
+
+  for (const ktpDomain of ktpDomains) {
     try {
       const response = await fetchFn(ktpDomain, config)
 

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/dnsmasq.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/dnsmasq.ts
@@ -4,6 +4,7 @@ import process from 'node:process'
 import { Config } from './config.ts'
 import { DiscoveredKTP } from './discovery.ts'
 import logger from './logger.ts'
+import * as db from './db.ts'
 
 async function restartDnsmasq(config: Config) {
   logger.debug('Restarting dnsmasq')
@@ -44,7 +45,6 @@ async function removeDnsmasqConfig(config: Config) {
   }
 }
 
-
 function checkForDuplicatesAndRemove(discovered: DiscoveredKTP[]): DiscoveredKTP[] {
   const grouped = _.groupBy(discovered, x => x.alias)
 
@@ -65,15 +65,20 @@ function checkForDuplicatesAndRemove(discovered: DiscoveredKTP[]): DiscoveredKTP
 }
 
 export async function writeDnsmasqConfig(discovered: DiscoveredKTP[], config: Config) {
+  // Write entire scan result, including duplicates, to DB so we can always see the raw situation
+  db.upsertFriendlyNames(discovered)
+
+  // Read back the results from the DB so we can also include KTPs that were not online when this scan happened,
+  // and only then dedupe them so that we don't confuse dnsmasq
+  const allFriendlyNames = db.getFriendlyNames()
+  const deduped = checkForDuplicatesAndRemove(allFriendlyNames)
+
   if (Deno.env.get('CONSOLE_ONLY_OUTPUT') === 'true') {
     logger.info(`Console only output mode enabled, will not write any files and outputting results directly to stdout`)
-
-    console.log(JSON.stringify({ discovered }, null, 2))
-
+    console.log(JSON.stringify({ discovered: deduped }, null, 2))
     return
   }
 
-  const deduped = checkForDuplicatesAndRemove(discovered)
   const hostRecordEntries = deduped.map(x => `host-record=${x.alias},${x.target}`)
 
   if (hostRecordEntries.length === 0) {

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/dnsmasq.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/dnsmasq.ts
@@ -45,25 +45,6 @@ async function removeDnsmasqConfig(config: Config) {
   }
 }
 
-function checkForDuplicatesAndRemove(discovered: DiscoveredKTP[]): DiscoveredKTP[] {
-  const grouped = _.groupBy(discovered, x => x.alias)
-
-  const deduped: DiscoveredKTP[] = []
-
-  // There would be a more elegant way to do this straight away, but we want these instances to be logged for debugging, so doing it the more laborious way
-  for (const [alias, declarators] of Object.entries(grouped)) {
-    if (declarators.length > 1) {
-      logger.error(declarators, `Multiple KTPs in this network declare the same alias (${alias}):`)
-      logger.error(`To prevent confusion, until this conflict is remediated, this alias will not be mapped to any KTP`)
-      continue
-    }
-
-    deduped.push(declarators[0])
-  }
-
-  return deduped
-}
-
 export async function writeDnsmasqConfig(discovered: DiscoveredKTP[], config: Config) {
   // Write entire scan result, including duplicates, to DB so we can always see the raw situation
   db.upsertFriendlyNames(discovered)
@@ -71,15 +52,14 @@ export async function writeDnsmasqConfig(discovered: DiscoveredKTP[], config: Co
   // Read back the results from the DB so we can also include KTPs that were not online when this scan happened,
   // and only then dedupe them so that we don't confuse dnsmasq
   const allFriendlyNames = db.getFriendlyNames()
-  const deduped = checkForDuplicatesAndRemove(allFriendlyNames)
 
   if (Deno.env.get('CONSOLE_ONLY_OUTPUT') === 'true') {
     logger.info(`Console only output mode enabled, will not write any files and outputting results directly to stdout`)
-    console.log(JSON.stringify({ discovered: deduped }, null, 2))
+    console.log(JSON.stringify({ discovered: allFriendlyNames }, null, 2))
     return
   }
 
-  const hostRecordEntries = deduped.map(x => `host-record=${x.alias},${x.target}`)
+  const hostRecordEntries = allFriendlyNames.map(x => `host-record=${x.alias},${x.target}`)
 
   if (hostRecordEntries.length === 0) {
     logger.info(

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/main.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/main.ts
@@ -2,10 +2,13 @@ import logger from './logger.ts'
 import { discoverFriendlyNamesInNetwork } from './discovery.ts'
 import { writeDnsmasqConfig } from './dnsmasq.ts'
 import { parseArgs } from './cli.ts'
+import * as db from './db.ts'
 
 const args = parseArgs(Deno.args)
 if (!args) Deno.exit(1)
 const { config } = args
+
+db.init(config)
 
 logger.info(config, 'Running digabi2-examnet-discovery with config:')
 

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/util.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/util.ts
@@ -1,0 +1,11 @@
+import { DiscoveredKTP } from './discovery.ts'
+
+export function sortByKTPNumber(a: string, b: string) {
+  const aNum = +a.split('.')[0].replace(/\D/g, '')
+  const bNum = +b.split('.')[0].replace(/\D/g, '')
+  return aNum - bNum
+}
+
+export function sortDiscoveredKTPs(a: DiscoveredKTP, b: DiscoveredKTP) {
+  return sortByKTPNumber(a.address, b.address)
+}

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/dnsmasq.test.ts.snap
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/dnsmasq.test.ts.snap
@@ -1,12 +1,57 @@
 export const snapshot = {};
 
 snapshot[`dnsmasq config generation > writes valid dnsmasq configuration for detected KTPs 1`] = `
+[
+  {
+    address: "ktp1.1000.koe.abitti.net",
+    alias: "peruna.internal",
+    target: "192.168.10.1",
+  },
+  {
+    address: "ktp2.1000.koe.abitti.net",
+    alias: "nauris.internal",
+    target: "192.168.20.1",
+  },
+  {
+    address: "ktp3.1000.koe.abitti.net",
+    alias: "turnipsi.internal",
+    target: "192.168.30.1",
+  },
+]
+`;
+
+snapshot[`dnsmasq config generation > writes valid dnsmasq configuration for detected KTPs 2`] = `
 "host-record=peruna.internal,192.168.10.1
 host-record=nauris.internal,192.168.20.1
 host-record=turnipsi.internal,192.168.30.1"
 `;
 
-snapshot[`dnsmasq config generation > ignores KTPs that have the same alias declared 1`] = `
+snapshot[`dnsmasq config generation > stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates 1`] = `
+[
+  {
+    address: "ktp1.1000.koe.abitti.net",
+    alias: "peruna.internal",
+    target: "192.168.10.1",
+  },
+  {
+    address: "ktp2.1000.koe.abitti.net",
+    alias: "nauris.internal",
+    target: "192.168.20.1",
+  },
+  {
+    address: "ktp3.1000.koe.abitti.net",
+    alias: "turnipsi.internal",
+    target: "192.168.30.1",
+  },
+  {
+    address: "ktp4.1000.koe.abitti.net",
+    alias: "peruna.internal",
+    target: "192.168.40.1",
+  },
+]
+`;
+
+snapshot[`dnsmasq config generation > stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates 2`] = `
 "host-record=nauris.internal,192.168.20.1
 host-record=turnipsi.internal,192.168.30.1"
 `;

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/dnsmasq.test.ts.snap
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/dnsmasq.test.ts.snap
@@ -26,7 +26,7 @@ host-record=nauris.internal,192.168.20.1
 host-record=turnipsi.internal,192.168.30.1"
 `;
 
-snapshot[`dnsmasq config generation > stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates 1`] = `
+snapshot[`dnsmasq config generation > stores KTPs that have the same alias declared 1`] = `
 [
   {
     address: "ktp1.1000.koe.abitti.net",
@@ -51,7 +51,9 @@ snapshot[`dnsmasq config generation > stores even KTPs that have the same alias 
 ]
 `;
 
-snapshot[`dnsmasq config generation > stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates 2`] = `
-"host-record=nauris.internal,192.168.20.1
-host-record=turnipsi.internal,192.168.30.1"
+snapshot[`dnsmasq config generation > stores KTPs that have the same alias declared 2`] = `
+"host-record=peruna.internal,192.168.10.1
+host-record=nauris.internal,192.168.20.1
+host-record=turnipsi.internal,192.168.30.1
+host-record=peruna.internal,192.168.40.1"
 `;

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/dnsmasq.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/dnsmasq.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, beforeEach } from '@std/testing/bdd'
 import { assertSnapshot } from '@std/testing/snapshot'
+import { expect } from '@std/expect'
 import { ensureDir, emptyDir } from '@std/fs'
 import { DiscoveredKTP } from '../src/discovery.ts'
 import { writeDnsmasqConfig } from '../src/dnsmasq.ts'
 import { config } from './test-config.ts'
+import * as db from '../src/db.ts'
 
 describe('dnsmasq config generation', () => {
   beforeEach(async () => {
     await emptyDir('devconf')
     await ensureDir('devconf')
+    db.init(config)
   })
 
   it('writes valid dnsmasq configuration for detected KTPs', async ctx => {
@@ -19,10 +22,12 @@ describe('dnsmasq config generation', () => {
     ]
 
     await writeDnsmasqConfig(discovered, config)
+
+    await assertSnapshot(ctx, db.getFriendlyNames())
     await assertSnapshot(ctx, await Deno.readTextFile(config.dnsmasqConfigOutputFile))
   })
 
-  it('ignores KTPs that have the same alias declared', async ctx => {
+  it('stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates', async ctx => {
     const discovered: DiscoveredKTP[] = [
       { address: 'ktp1.1000.koe.abitti.net', target: '192.168.10.1', alias: 'peruna.internal' },
       { address: 'ktp2.1000.koe.abitti.net', target: '192.168.20.1', alias: 'nauris.internal' },
@@ -31,6 +36,38 @@ describe('dnsmasq config generation', () => {
     ]
 
     await writeDnsmasqConfig(discovered, config)
+
+    await assertSnapshot(ctx, db.getFriendlyNames())
     await assertSnapshot(ctx, await Deno.readTextFile(config.dnsmasqConfigOutputFile))
+  })
+
+  it('on subsequent scans, previously detected KTPs are included even if they are now offline', async () => {
+    const discovered1: DiscoveredKTP[] = [
+      { address: 'ktp1.1000.koe.abitti.net', target: '192.168.10.1', alias: 'peruna.internal' },
+      { address: 'ktp2.1000.koe.abitti.net', target: '192.168.20.1', alias: 'nauris.internal' },
+      { address: 'ktp3.1000.koe.abitti.net', target: '192.168.30.1', alias: 'turnipsi.internal' }
+    ]
+
+    await writeDnsmasqConfig(discovered1, config)
+    expect(db.getFriendlyNames()).toEqual(discovered1)
+
+    const dnsmasq1 = [
+      'host-record=peruna.internal,192.168.10.1',
+      'host-record=nauris.internal,192.168.20.1',
+      'host-record=turnipsi.internal,192.168.30.1'
+    ].join('\n')
+
+    expect(await Deno.readTextFile(config.dnsmasqConfigOutputFile)).toEqual(dnsmasq1)
+
+    const discovered2: DiscoveredKTP[] = [
+      { address: 'ktp1.1000.koe.abitti.net', target: '192.168.10.1', alias: 'peruna.internal' },
+      { address: 'ktp2.1000.koe.abitti.net', target: '192.168.20.1', alias: 'nauris.internal' }
+    ]
+
+    await writeDnsmasqConfig(discovered2, config)
+
+    // Result in DB and in dnsmasq should not change, the one previously online should be included
+    expect(db.getFriendlyNames()).toEqual(discovered1)
+    expect(await Deno.readTextFile(config.dnsmasqConfigOutputFile)).toEqual(dnsmasq1)
   })
 })

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/dnsmasq.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/dnsmasq.test.ts
@@ -27,7 +27,7 @@ describe('dnsmasq config generation', () => {
     await assertSnapshot(ctx, await Deno.readTextFile(config.dnsmasqConfigOutputFile))
   })
 
-  it('stores even KTPs that have the same alias declared, but only writes dnsmasq config for ones without duplicates', async ctx => {
+  it('stores KTPs that have the same alias declared', async ctx => {
     const discovered: DiscoveredKTP[] = [
       { address: 'ktp1.1000.koe.abitti.net', target: '192.168.10.1', alias: 'peruna.internal' },
       { address: 'ktp2.1000.koe.abitti.net', target: '192.168.20.1', alias: 'nauris.internal' },

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/test-config.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/test-config.ts
@@ -7,7 +7,8 @@ export const config = ConfigSchema.parse({
   ktpDomains: Array(24)
     .fill(undefined)
     .map((_, i) => `ktp${i + 1}.1000.koe.abitti.net`),
-  ports: { discovery: 26464 }
+  ports: { discovery: 26464 },
+  dbPath: 'devconf/test__discovery.db'
 } satisfies Config)
 
 export const FAKE_KTPS: Record<string, DiscoveryResponse> = {

--- a/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -61,6 +61,7 @@ readonly PATH_SERVER_FRIENDLY_NAME_CONF=$PATH_EXAMNET_CONFIG/server-friendly-nam
 readonly PATH_NET_DEVICE_LAN_CONF=$PATH_EXAMNET_CONFIG/net-device-lan
 readonly PATH_NET_DEVICE_WAN_CONF=$PATH_EXAMNET_CONFIG/net-device-wan
 readonly PATH_SERVER_OWN_IP=$PATH_EXAMNET_CONFIG/server-own-ip
+readonly PATH_DISCOVERY_DB=$PATH_EXAMNET_CONFIG/discovery.db
 
 readonly BIN_ECHO=/usr/bin/echo
 readonly BIN_GREP=/usr/bin/grep
@@ -345,6 +346,11 @@ function remove_all_settings() {
         exit_if_error $? $EXIT_CODE_CANNOT_REMOVE_FILES "Failed to remove system file '$PATH_SERVER_OWN_IP'"
     fi
 
+    if [ -f $PATH_DISCOVERY_DB ]; then
+        rm -f $PATH_DISCOVERY_DB
+        exit_if_error $? $EXIT_CODE_CANNOT_REMOVE_FILES "Failed to remove system file '$PATH_DISCOVERY_DB'"
+    fi
+
     remove_dnsmasq_settings
     remove_school_host_entries
 
@@ -585,7 +591,8 @@ if [[ $* == *--discover* ]]; then
             "isProd": true,
             "ktpDomains": $(jq -Rcs '[. | split("\n") | .[] | match("host-record=(.+),.+").captures[0].string]' "$PATH_DNSMASQ_STATIC_DNS_CONF"),
             "dnsmasqConfigOutputFile": "$PATH_DNSMASQ_KTP_ALIASES_CONF",
-            "ports": {"discovery": $DISCOVERY_PORT}
+            "ports": {"discovery": $DISCOVERY_PORT},
+            "dbPath": "$PATH_DISCOVERY_DB"
         }
     }
 EOF


### PR DESCRIPTION
Discovery-järjestelmä tallentaa nyt havaitsemansa KTP:t SQLite-kantaan. Tämä tarkoittaa sitä, että vaikka palvelimen sammuttaa (joko väliaikaisesti tai pitempiaikaisesti), muistavat verkossa olleet palvelimet sen lempinimen. Sitten jos ja kun palvelin ilmestyy taas linjoille, aletaan siltä taas keräämään lempinimeä.

Discovery-kanta poistetaan verkkoasetusten poiston yhteydessä. Tällä varmistetaan se, että esim. koulunumeron vaihtuessa kantaan ei jää roikkumaan vanhoja lempinimiä.