### PR TITLE
Prevent upstream DNS queries of NCSI domain names

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -37,3 +37,4 @@ server=/koe.abitti.net/#
 # This prevents software on the student computer from getting confused by when DNS queries work, but the TCP
 # request stalls (since this is not a router) for however long the client timeout is set to; possibly Infinity
 address=/#/0.0.0.0
+address=/#/::

--- a/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -16,6 +16,8 @@ dhcp-option=option:domain-name,${FRIENDLY_NAME_SEARCH_DOMAIN}
 
 # Redirect requests for Windows Network Connection Status Indicator (NCSI) to our local NCSI spoofer (digabi2-examnet-bouncer)
 host-record=${NCSI_HOSTNAMES_LIST},${SERVER_OWN_IP}
+# Avoid resolving NCSI IPv6 addresses from upstream DNS
+host-record=${NCSI_HOSTNAMES_LIST},::
 
 # --- temporary ---
 domain=internal


### PR DESCRIPTION
Without setting upstream DNS servers to none, the dnsmasq resolves the IPv6 addresses. In the case of NCSI servers the upstream server returns CNAME-record, which is resolved by dnsmasq to 127.0.0.1.

When client tries to get the valid NCSI response from 127.0.0.1 it obviously fails which causes NCSI to switch the network.