### PR TITLE
 Forward requests to koe.ylioppilastutkinto.fi to upstream

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/Makefile
+++ b/packages/ytl-linux-digabi2-examnet/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2-examnet
-VERSION := 0.2.1
+VERSION := 0.2.2
 
 DEPENDENCIES := \
 	--depends apt \

--- a/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -19,11 +19,6 @@ host-record=${NCSI_HOSTNAMES_LIST},${SERVER_OWN_IP}
 # Avoid resolving NCSI IPv6 addresses from upstream DNS
 host-record=${NCSI_HOSTNAMES_LIST},::
 
-# --- temporary ---
-domain=internal
-dhcp-option=option:domain-name,internal
-host-record=${SERVER_FRIENDLY_NAME}.internal,${SERVER_OWN_IP}
-
 # Use WAN device nameservers as upstream
 resolv-file=/etc/resolv.conf
 

--- a/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -28,6 +28,13 @@ resolv-file=/etc/resolv.conf
 # need DNS to tell student computers where to go
 server=/koe.abitti.net/#
 
+# Forward requests to koe.ylioppilastutkinto.fi to upstream
+# This is to allow other KTPs that temporarily receive DHCP from this server to still resolve the correct address and be able to
+# contact it on its external network interface (that does not lead to this KTP). If we did not do this, the KTP would get
+# koe.ylioppilastutkinto.fi => 0.0.0.0 and be unable to make the request, even on the correct network interface.
+# Student machines will not be able to contact koe.ylioppilastutkinto.fi either way, since they will get blocked by iptables
+server=/koe.ylioppilastutkinto.fi/#
+
 # Null-route all other traffic
 # This prevents software on the student computer from getting confused by when DNS queries work, but the TCP
 # request stalls (since this is not a router) for however long the client timeout is set to; possibly Infinity


### PR DESCRIPTION
Sisarus-PR Naksu 2:ssa: https://github.com/digabi/naksu2/pull/508.

Pääasialliset selitykset ovat tuossa Naksu-PR:ssä, mutta kirjataan nyt tännekin olennaiset osat historian annaaleihin: Sallitaan KTP:n DNS:n reitittää koe.ylioppilastutkinto.fi oikein, jotta verkkoon tuotava toinen KTP, joka saa siltä osoitteen, pystyy löytämään oikeaan paikkaan hakeakseen varmenteensa ja tehdäkseen verkkoasetuksensa.

Tällä ei ole vaikutuksia kokelaaseen, koska tuleva iptables-pohjainen palomuuri ei kumminkaan sallisi kokelaskoneelta tulevaa liikennettä lävitseen koe.ylioppilastutkinto.fi:hin. KTP:n tekemä liikenne ei myöskään mene toisen KTP:n kautta tässä tapauksessa, johtuen Naksussa olevasta toteutuksesta. Sen lisäksi koe.ylioppilastutkinto.fi:ssä ei ole kokelaan kannalta mitään mielenkiintoista.

Korjattu myös ilmeisen vahingossa käytetty sisäinen pitkä URL tutkintopalvelulle, koska lyhytversio toimii. Korjattu myös vahingossa mukaan livahtanut väliaikainen konffi siltä ajalta, kun examnettiä rempattiin.