### PR TITLE
discover ktps in parallel with greater timeout

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/Makefile
+++ b/packages/ytl-linux-digabi2-examnet/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2-examnet
-VERSION := 1.2.3
+VERSION := 1.3.0
 
 DEPENDENCIES := \
 	--depends apt \

--- a/packages/ytl-linux-digabi2-examnet/discovery/src/discovery.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/src/discovery.ts
@@ -25,7 +25,7 @@ export async function fetchFromDiscoveryEndpoint(ktpDomain: string, config: Conf
   logger.debug(`Asking ${ktpDomain} for alias using URL ${discoveryUrl}`)
 
   return await fetch(discoveryUrl, {
-    signal: AbortSignal.timeout(1000)
+    signal: AbortSignal.timeout(5000)
   })
 }
 
@@ -33,45 +33,46 @@ export async function discoverFriendlyNamesInNetwork(
   config: Config,
   fetchFn = fetchFromDiscoveryEndpoint
 ): Promise<DiscoveredKTP[]> {
-  const discovered: DiscoveredKTP[] = []
-
   // Sort the domains so that the logs make a bit more sense, since the certificate SANs are sorted by "natural order" (i.e. 1, 10, 11, ... 2, 20, 21, ...) and not KTP number order
   const ktpDomains = config.ktpDomains.toSorted(sortByKTPNumber)
 
-  for (const ktpDomain of ktpDomains) {
-    try {
-      const response = await fetchFn(ktpDomain, config)
+  const results = await Promise.allSettled(
+    ktpDomains.map(async ktpDomain => {
+      try {
+        const response = await fetchFn(ktpDomain, config)
 
-      if (!response.ok) {
-        logger.warn(`${ktpDomain} responded with ${response.status} ${response.statusText}, skipping it`)
-        logger.warn(`Response body: ${await response.text()}`)
-        continue
+        if (!response.ok) {
+          logger.warn(`${ktpDomain} responded with ${response.status} ${response.statusText}, skipping it`)
+          logger.warn(`Response body: ${await response.text()}`)
+          return
+        }
+
+        const responseJson = await response.json()
+        const discoveryResponse = DiscoveryResponseSchema.safeParse(responseJson)
+
+        if (!discoveryResponse.success) {
+          logger.warn(`${ktpDomain} responded with invalid JSON shape, skipping it`)
+          logger.warn(`Response body: ${JSON.stringify(responseJson)}`)
+          return
+        }
+
+        const { target, alias } = discoveryResponse.data
+
+        logger.debug(`${ktpDomain} declares alias ${alias} => ${target}`)
+
+        return {
+          address: ktpDomain,
+          target,
+          alias
+        }
+      } catch (err) {
+        logger.debug(`${ktpDomain} did not respond validly, assuming it's down or otherwise unreachable`)
+        logger.debug(`Error message: ${err instanceof Error ? err.message : err}`)
+        logger.trace(err, `Exact error:`)
+        return
       }
+    })
+  )
 
-      const responseJson = await response.json()
-      const discoveryResponse = DiscoveryResponseSchema.safeParse(responseJson)
-
-      if (!discoveryResponse.success) {
-        logger.warn(`${ktpDomain} responded with invalid JSON shape, skipping it`)
-        logger.warn(`Response body: ${JSON.stringify(responseJson)}`)
-        continue
-      }
-
-      const { target, alias } = discoveryResponse.data
-
-      logger.debug(`${ktpDomain} declares alias ${alias} => ${target}`)
-
-      discovered.push({
-        address: ktpDomain,
-        target,
-        alias
-      })
-    } catch (err) {
-      logger.debug(`${ktpDomain} did not respond validly, assuming it's down or otherwise unreachable`)
-      logger.debug(`Error message: ${err instanceof Error ? err.message : err}`)
-      logger.trace(err, `Exact error:`)
-    }
-  }
-
-  return Object.values(discovered)
+  return results.flatMap(x => (x.status === 'fulfilled' ? (x.value ? [x.value] : []) : []))
 }

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/discovery.test.ts.snap
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/__snapshots__/discovery.test.ts.snap
@@ -349,3 +349,73 @@ snapshot[`KTP discovery > ignores KTPs that respond with invalidly shaped JSON 1
   },
 ]
 `;
+
+snapshot[`KTP discovery > waits for slow KTPs to respond 1`] = `
+[
+  {
+    address: "ktp2.1000.koe.abitti.net",
+    alias: "nauris.internal",
+    target: "192.168.20.1",
+  },
+  {
+    address: "ktp3.1000.koe.abitti.net",
+    alias: "turnipsi.internal",
+    target: "192.168.30.1",
+  },
+  {
+    address: "ktp4.1000.koe.abitti.net",
+    alias: "porkkana.internal",
+    target: "192.168.40.1",
+  },
+  {
+    address: "ktp5.1000.koe.abitti.net",
+    alias: "lanttu.internal",
+    target: "192.168.50.1",
+  },
+  {
+    address: "ktp6.1000.koe.abitti.net",
+    alias: "retiisi.internal",
+    target: "192.168.60.1",
+  },
+  {
+    address: "ktp7.1000.koe.abitti.net",
+    alias: "purjo.internal",
+    target: "192.168.70.1",
+  },
+  {
+    address: "ktp8.1000.koe.abitti.net",
+    alias: "sipuli.internal",
+    target: "192.168.80.1",
+  },
+  {
+    address: "ktp9.1000.koe.abitti.net",
+    alias: "kukkakaali.internal",
+    target: "192.168.90.1",
+  },
+  {
+    address: "ktp20.1000.koe.abitti.net",
+    alias: "artisokka.internal",
+    target: "192.168.200.1",
+  },
+  {
+    address: "ktp21.1000.koe.abitti.net",
+    alias: "endiivi.internal",
+    target: "192.168.210.1",
+  },
+  {
+    address: "ktp22.1000.koe.abitti.net",
+    alias: "avokado.internal",
+    target: "192.168.220.1",
+  },
+  {
+    address: "ktp23.1000.koe.abitti.net",
+    alias: "munakoiso.internal",
+    target: "192.168.230.1",
+  },
+  {
+    address: "ktp24.1000.koe.abitti.net",
+    alias: "sokerijuurikas.internal",
+    target: "192.168.240.1",
+  },
+]
+`;

--- a/packages/ytl-linux-digabi2-examnet/discovery/tests/discovery.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/discovery/tests/discovery.test.ts
@@ -54,4 +54,23 @@ describe('KTP discovery', () => {
 
     await assertSnapshot(ctx, discovered)
   })
+
+  it('waits for slow KTPs to respond', async ctx => {
+    const discovered = await discoverFriendlyNamesInNetwork(config, async ktpDomain => {
+      // intent: ktp1 and ktp10-ktp19 are absent from the result
+      const fuzz = Math.random() * 999
+      const delayTime = (ktpDomain.startsWith('ktp1') ? 1000 : 0) + fuzz
+      const resolvableTimeout = Promise.withResolvers<void>()
+      const timeout = setTimeout(() => resolvableTimeout.reject('simulated timeout'), 1000)
+      const delay = setTimeout(() => resolvableTimeout.resolve(), delayTime)
+      try {
+        await resolvableTimeout.promise
+        return fakeDiscoveryResponse(200, FAKE_KTPS[ktpDomain])
+      } finally {
+        clearTimeout(timeout)
+        clearTimeout(delay)
+      }
+    })
+    await assertSnapshot(ctx, discovered)
+  })
 })


### PR DESCRIPTION
päätettiin olla ottamatta kantaa konflikteihin, joten palvelinten läpikäynti yksitellen ei ole tarkoituksenmukaista.