### PR TITLE
Add more domains to list of allowed domains

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
@@ -690,9 +690,9 @@ describe('examnet (just port)', () => {
         callSystemctl('restart', 'ytl-linux-digabi2-examnet'),
         callSystemctl('restart', 'ytl-linux-digabi2-examnet-discovery.timer'),
         callSystemctl('restart', 'ytl-linux-digabi2-examnet-discovery.service'),
-        callDig('endpoint.security.microsoft.com'),
-        callDig('smartscreen-prod.microsoft.com'),
-        callDig('smartscreen.microsoft.com')
+        ...callDig(
+          'microsoft.com windows.com microsoftonline.com msidentity.com live.com live.net windowsupdate.com trafficmanager.net akamaiedge.net edgekey.net akadns.net fastly.net digicert.com globalsign.com skype.com'
+        )
       ])
       await assertFileExists(mockExamnetConfigDir, 'net-device-lan')
       await assertFileExists(mockExamnetConfigDir, 'net-device-wan')
@@ -741,14 +741,38 @@ describe('examnet (just port)', () => {
           'server=/oma.abitti.fi/#\n' +
           '\n' +
           '# Forward also requests to allowlisted domains to upstream\n' +
-          'server=/endpoint.security.microsoft.com/#\n' +
-          'server=/smartscreen-prod.microsoft.com/#\n' +
-          'server=/smartscreen.microsoft.com/#\n' +
+          'server=/microsoft.com/#\n' +
+          'server=/windows.com/#\n' +
+          'server=/microsoftonline.com/#\n' +
+          'server=/msidentity.com/#\n' +
+          'server=/live.com/#\n' +
+          'server=/live.net/#\n' +
+          'server=/windowsupdate.com/#\n' +
+          'server=/trafficmanager.net/#\n' +
+          'server=/akamaiedge.net/#\n' +
+          'server=/edgekey.net/#\n' +
+          'server=/akadns.net/#\n' +
+          'server=/fastly.net/#\n' +
+          'server=/digicert.com/#\n' +
+          'server=/globalsign.com/#\n' +
+          'server=/skype.com/#\n' +
           '\n' +
           '# IP addresses of allowlisted domains are added to ipset that is used to allow forwarding traffic to those domains in iptables\n' +
-          'ipset=/endpoint.security.microsoft.com/ytl_internet_allowlist\n' +
-          'ipset=/smartscreen-prod.microsoft.com/ytl_internet_allowlist\n' +
-          'ipset=/smartscreen.microsoft.com/ytl_internet_allowlist\n' +
+          'ipset=/microsoft.com/ytl_internet_allowlist\n' +
+          'ipset=/windows.com/ytl_internet_allowlist\n' +
+          'ipset=/microsoftonline.com/ytl_internet_allowlist\n' +
+          'ipset=/msidentity.com/ytl_internet_allowlist\n' +
+          'ipset=/live.com/ytl_internet_allowlist\n' +
+          'ipset=/live.net/ytl_internet_allowlist\n' +
+          'ipset=/windowsupdate.com/ytl_internet_allowlist\n' +
+          'ipset=/trafficmanager.net/ytl_internet_allowlist\n' +
+          'ipset=/akamaiedge.net/ytl_internet_allowlist\n' +
+          'ipset=/edgekey.net/ytl_internet_allowlist\n' +
+          'ipset=/akadns.net/ytl_internet_allowlist\n' +
+          'ipset=/fastly.net/ytl_internet_allowlist\n' +
+          'ipset=/digicert.com/ytl_internet_allowlist\n' +
+          'ipset=/globalsign.com/ytl_internet_allowlist\n' +
+          'ipset=/skype.com/ytl_internet_allowlist\n' +
           '\n' +
           '# Null-route all other traffic\n' +
           '# This prevents software on the student computer from getting confused by when DNS queries work, but the TCP\n' +
@@ -888,9 +912,9 @@ describe('examnet (just port)', () => {
         callSystemctl('restart', 'ytl-linux-digabi2-examnet'),
         callSystemctl('restart', 'ytl-linux-digabi2-examnet-discovery.timer'),
         callSystemctl('restart', 'ytl-linux-digabi2-examnet-discovery.service'),
-        callDig('endpoint.security.microsoft.com'),
-        callDig('smartscreen-prod.microsoft.com'),
-        callDig('smartscreen.microsoft.com')
+        ...callDig(
+          'microsoft.com windows.com microsoftonline.com msidentity.com live.com live.net windowsupdate.com trafficmanager.net akamaiedge.net edgekey.net akadns.net fastly.net digicert.com globalsign.com skype.com'
+        )
       ])
 
       await assertFileExists(mockExamnetConfigDir, 'net-device-lan')
@@ -940,14 +964,38 @@ describe('examnet (just port)', () => {
           'server=/oma.abitti.fi/#\n' +
           '\n' +
           '# Forward also requests to allowlisted domains to upstream\n' +
-          'server=/endpoint.security.microsoft.com/#\n' +
-          'server=/smartscreen-prod.microsoft.com/#\n' +
-          'server=/smartscreen.microsoft.com/#\n' +
+          'server=/microsoft.com/#\n' +
+          'server=/windows.com/#\n' +
+          'server=/microsoftonline.com/#\n' +
+          'server=/msidentity.com/#\n' +
+          'server=/live.com/#\n' +
+          'server=/live.net/#\n' +
+          'server=/windowsupdate.com/#\n' +
+          'server=/trafficmanager.net/#\n' +
+          'server=/akamaiedge.net/#\n' +
+          'server=/edgekey.net/#\n' +
+          'server=/akadns.net/#\n' +
+          'server=/fastly.net/#\n' +
+          'server=/digicert.com/#\n' +
+          'server=/globalsign.com/#\n' +
+          'server=/skype.com/#\n' +
           '\n' +
           '# IP addresses of allowlisted domains are added to ipset that is used to allow forwarding traffic to those domains in iptables\n' +
-          'ipset=/endpoint.security.microsoft.com/ytl_internet_allowlist\n' +
-          'ipset=/smartscreen-prod.microsoft.com/ytl_internet_allowlist\n' +
-          'ipset=/smartscreen.microsoft.com/ytl_internet_allowlist\n' +
+          'ipset=/microsoft.com/ytl_internet_allowlist\n' +
+          'ipset=/windows.com/ytl_internet_allowlist\n' +
+          'ipset=/microsoftonline.com/ytl_internet_allowlist\n' +
+          'ipset=/msidentity.com/ytl_internet_allowlist\n' +
+          'ipset=/live.com/ytl_internet_allowlist\n' +
+          'ipset=/live.net/ytl_internet_allowlist\n' +
+          'ipset=/windowsupdate.com/ytl_internet_allowlist\n' +
+          'ipset=/trafficmanager.net/ytl_internet_allowlist\n' +
+          'ipset=/akamaiedge.net/ytl_internet_allowlist\n' +
+          'ipset=/edgekey.net/ytl_internet_allowlist\n' +
+          'ipset=/akadns.net/ytl_internet_allowlist\n' +
+          'ipset=/fastly.net/ytl_internet_allowlist\n' +
+          'ipset=/digicert.com/ytl_internet_allowlist\n' +
+          'ipset=/globalsign.com/ytl_internet_allowlist\n' +
+          'ipset=/skype.com/ytl_internet_allowlist\n' +
           '\n' +
           '# Null-route all other traffic\n' +
           '# This prevents software on the student computer from getting confused by when DNS queries work, but the TCP\n' +
@@ -1510,8 +1558,13 @@ function callSudoTeeWriteToFile(file: string) {
   return { cmd: 'sudo', argv: ['tee', file] }
 }
 
-function callDig(host: string) {
-  return { cmd: 'dig', argv: ['+time=1', '+tries=1', '@192.168.10.1', host, 'A'] }
+function callDig(hosts: string) {
+  const result = []
+  const hostsArray = hosts.split(' ')
+  for (const host of hostsArray) {
+    result.push({ cmd: 'dig', argv: ['+time=1', '+tries=1', '@192.168.10.1', host, 'A'] })
+  }
+  return result
 }
 
 function callIpsetCreate(list: string) {

--- a/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -23,7 +23,7 @@ export FRIENDLY_NAME_SEARCH_DOMAIN="internal"
 export DISCOVERY_PORT=26464
 export BOUNCER_PORT=80
 
-export INTERNET_ALLOWLIST_DOMAINS="endpoint.security.microsoft.com smartscreen-prod.microsoft.com smartscreen.microsoft.com"
+export INTERNET_ALLOWLIST_DOMAINS="microsoft.com windows.com microsoftonline.com msidentity.com live.com live.net windowsupdate.com trafficmanager.net akamaiedge.net edgekey.net akadns.net fastly.net digicert.com globalsign.com skype.com"
 export INTERNET_ALLOWLIST_IPSET_NAME="ytl_internet_allowlist"
 export INTERNET_ALLOWLIST_FILTER_CHAIN="YTL_LAN_WAN_IPSET"
 export INTERNET_ALLOWLIST_IPSET_TIMEOUT_SECONDS=3600


### PR DESCRIPTION
- include roughly everything that could be relevant to Microsoft Defender
- Use main level domains in allowlist, since there are so many subdomains that need to be allowed