### PR TITLE
Add internal docker network to dnsmasq & network manager config

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
+++ b/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
@@ -4,6 +4,10 @@
 match-device=interface-name:ytl0
 managed=0
 
+[device-ytl1-unmanaged]
+match-device=interface-name:ytl1
+managed=0
+
 [device-docker0-unmanaged]
 match-device=interface-name:docker0
 managed=0

--- a/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
+++ b/packages/ytl-linux-digabi2-examnet/templates/dnsmasq.conf.template
@@ -5,6 +5,7 @@ log-queries=extra
 interface=${NET_DEVICE_LAN}
 interface=docker0
 interface=ytl0
+interface=ytl1
 
 # Set search domain to ktp to support server aliases
 domain=${FRIENDLY_NAME_SEARCH_DOMAIN}

--- a/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
@@ -709,6 +709,7 @@ describe('examnet (just port)', () => {
           'interface=eth1\n' +
           'interface=docker0\n' +
           'interface=ytl0\n' +
+          'interface=ytl1\n' +
           '\n' +
           '# Set search domain to ktp to support server aliases\n' +
           'domain=internal\n' +
@@ -932,6 +933,7 @@ describe('examnet (just port)', () => {
           'interface=eth1\n' +
           'interface=docker0\n' +
           'interface=ytl0\n' +
+          'interface=ytl1\n' +
           '\n' +
           '# Set search domain to ktp to support server aliases\n' +
           'domain=internal\n' +
@@ -1299,6 +1301,7 @@ describe('examnet (just port)', () => {
         'interface=${NET_DEVICE_LAN}\n' +
         'interface=docker0\n' +
         'interface=ytl0\n' +
+        'interface=ytl1\n' +
         '\n' +
         '# Set search domain to ktp to support server aliases\n' +
         'domain=${FRIENDLY_NAME_SEARCH_DOMAIN}\n' +


### PR DESCRIPTION
- Listen to `ytl1` (internal Docker network) with dnsmasq
- Prevent NetworkManager from managing `ytl1` (internal Docker network)
