### PR TITLE
Exclude Docker virtual switches from NetworkManager management

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/Makefile
+++ b/packages/ytl-linux-digabi2-examnet/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2-examnet
-VERSION := 1.5.0
+VERSION := 1.5.1
 
 DEPENDENCIES := \
 	--depends apt \

--- a/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
+++ b/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
@@ -1,13 +1,13 @@
 # Prevent NetworkManager from attempting to manage Docker's network devices,
-# causing performance degradation when Abitti 2 server is running
-[device-ytl0-unmanaged]
-match-device=interface-name:ytl0
-managed=0
+# causing performance degradation and other incredibly obscure failure conditions
+# when Abitti 2 server is running
 
-[device-ytl1-unmanaged]
-match-device=interface-name:ytl1
-managed=0
-
-[device-docker0-unmanaged]
+# Docker's default network bridge network device
+[device-docker-unmanaged]
 match-device=interface-name:docker0
+managed=0
+
+# KTP bridge networks (public ytl0 and internal ytl1)
+[device-ytl-unmanaged]
+match-device=interface-name:ytl*
 managed=0

--- a/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
+++ b/packages/ytl-linux-digabi2-examnet/NetworkManager/99-ytl-linux-unmanage-docker.conf
@@ -11,3 +11,8 @@ managed=0
 [device-ytl-unmanaged]
 match-device=interface-name:ytl*
 managed=0
+
+# Docker-created virtual switches (veth)
+[device-veth-unmanaged]
+match-device=interface-name:veth*
+managed=0


### PR DESCRIPTION
Eräässä tapauksessa tuli vastaan tilanne, jossa verkkolaitteita oli jotenkin säädetty NetworkManagerissa, ja tämä oli päätynyt vaikuttamaan Dockerin virtuaalikytkimiin (`veth`-alkuiset verkkolaitteet), joka sitten sotki Abitti 2-palvelimen sisäistä verkkoliikennettä. Otetaan siis pois Dockerin virtuaalikytkimet pois NetworkManagerin hallinnasta, jotta käyttäjä ei voi niitä enemmän tahi vähemmän tahallisesti sotkea NetworkManagerilla. Tämä on myös hyvä idea sikäli, että NetworkManager itse ei voi vahingossa sotkea niitä.

Samalla kun minulle selvisi, että verkkolaitteiden nimiä voi matchata wildcardilla, kondensoin `ytl*`-verkkolaitteiden konfiguraation yhteen osioon. Lisäsin myös hiukan kattavammat selitykset siitä, miksi tämä konffi on olemassa ja mitä se tekee missäkin.