### PR TITLE
Restore internet forwarding at boot

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/Makefile
+++ b/packages/ytl-linux-digabi2-examnet/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-digabi2-examnet
-VERSION := 1.5.1
+VERSION := 1.6.0
 
 DEPENDENCIES := \
 	--depends apt \
@@ -50,6 +50,7 @@ deb:
 	# systemd unit files
 	mkdir -p $(DEB_ROOT)/etc/systemd/system/
 	cp ytl-linux-digabi2-examnet.service $(DEB_ROOT)/etc/systemd/system/
+	cp ytl-linux-digabi2-examnet-firewall.service $(DEB_ROOT)/etc/systemd/system/
 	cp ytl-linux-digabi2-examnet-discovery.service $(DEB_ROOT)/etc/systemd/system/
 	cp ytl-linux-digabi2-examnet-discovery.timer $(DEB_ROOT)/etc/systemd/system/
 	cp ytl-linux-digabi2-wait-for-listen-ip.service $(DEB_ROOT)/etc/systemd/system/

--- a/packages/ytl-linux-digabi2-examnet/after-install.sh
+++ b/packages/ytl-linux-digabi2-examnet/after-install.sh
@@ -12,6 +12,7 @@ if [[ -f /etc/systemd/system/ytl-linux-digabi2-ncsi.service ]]; then
 fi
 
 systemctl enable ytl-linux-digabi2-examnet
+systemctl enable ytl-linux-digabi2-examnet-firewall.service
 systemctl enable ytl-linux-digabi2-examnet-discovery.timer
 systemctl enable ytl-linux-digabi2-examnet-discovery.service
 systemctl enable ytl-linux-digabi2-wait-for-listen-ip.service

--- a/packages/ytl-linux-digabi2-examnet/before-remove.sh
+++ b/packages/ytl-linux-digabi2-examnet/before-remove.sh
@@ -12,6 +12,9 @@ fi
 systemctl stop ytl-linux-digabi2-examnet
 systemctl disable ytl-linux-digabi2-examnet
 
+systemctl stop ytl-linux-digabi2-examnet-firewall.service
+systemctl disable ytl-linux-digabi2-examnet-firewall.service
+
 systemctl stop ytl-linux-digabi2-examnet-discovery.timer
 systemctl disable ytl-linux-digabi2-examnet-discovery.timer
 

--- a/packages/ytl-linux-digabi2-examnet/justfile
+++ b/packages/ytl-linux-digabi2-examnet/justfile
@@ -53,5 +53,8 @@ restart-bouncer: util::assert-user-is-root
 discovery: util::assert-user-is-root
     just mod-discovery start
 
+restore-internet-forwarding: util::assert-user-is-root
+    just setup restore-internet-forwarding
+
 wait-for-listen-ip:
     just mod-wait-for-listen-ip start

--- a/packages/ytl-linux-digabi2-examnet/lib/setup.just
+++ b/packages/ytl-linux-digabi2-examnet/lib/setup.just
@@ -110,6 +110,7 @@ apply net-device-wan net-device-lan server-number server-friendly-name: \
   # Enable relevant systemd services
   just systemd enable ytl-linux-digabi2-examnet
   just systemd enable dnsmasq
+  just systemd enable ytl-linux-digabi2-examnet-firewall.service
   just systemd enable ytl-linux-digabi2-examnet-discovery.service
   just systemd enable ytl-linux-digabi2-examnet-discovery.timer
 
@@ -125,6 +126,34 @@ apply net-device-wan net-device-lan server-number server-friendly-name: \
   just internet-forwarding populate-ipset $SERVER_OWN_IP $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET
 
   just log info "Examnet configuration applied successfully"
+
+
+restore-internet-forwarding: \
+  (util::assert-envs-set EXIT_CODE_CANNOT_CONFIGURE_EXAMNET
+    "PATH_NET_DEVICE_WAN_CONF"
+    "PATH_NET_DEVICE_LAN_CONF"
+    "PATH_SERVER_OWN_IP"
+    "PATH_NAKSU2_DOMAIN"
+  )
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  if [[ ! -f "$PATH_NET_DEVICE_WAN_CONF" || ! -f "$PATH_NET_DEVICE_LAN_CONF" || ! -f "$PATH_SERVER_OWN_IP" ]]; then
+    just log info "Skipping internet forwarding restore because examnet is not configured"
+    exit 0
+  fi
+
+  NET_DEVICE_WAN=$(just fs read-file "$PATH_NET_DEVICE_WAN_CONF" "WAN network device" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET)
+  NET_DEVICE_LAN=$(just fs read-file "$PATH_NET_DEVICE_LAN_CONF" "LAN network device" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET)
+  SERVER_OWN_IP=$(just fs read-file "$PATH_SERVER_OWN_IP" "server own IP" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET)
+  THIS_SERVER_DOMAIN=$(just fs read-file "$PATH_NAKSU2_DOMAIN" "canonical server hostname" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET)
+
+  just log info "Restoring internet forwarding for WAN device '$NET_DEVICE_WAN' and LAN device '$NET_DEVICE_LAN'"
+
+  just internet-forwarding enable "$NET_DEVICE_WAN" "$NET_DEVICE_LAN" "$THIS_SERVER_DOMAIN" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET
+  just internet-forwarding populate-ipset "$SERVER_OWN_IP" $EXIT_CODE_CANNOT_CONFIGURE_EXAMNET
+
+  just log info "Internet forwarding restored successfully"
 
 
 destroy: \
@@ -151,6 +180,7 @@ destroy: \
 
   just systemd disable ytl-linux-digabi2-examnet
   just systemd disable dnsmasq
+  just systemd disable ytl-linux-digabi2-examnet-firewall.service
   just systemd disable ytl-linux-digabi2-examnet-discovery.timer
   just systemd disable ytl-linux-digabi2-examnet-discovery.service
 

--- a/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
+++ b/packages/ytl-linux-digabi2-examnet/test/examnet.test.ts
@@ -207,6 +207,13 @@ describe('examnet (just port)', () => {
     })
   })
 
+  describe('restore-internet-forwarding (--restore-internet-forwarding)', () => {
+    test('skips without error if examnet is not configured', async () => {
+      await runExamnetWithArguments(['--restore-internet-forwarding'], ENV_TEST_MODE)
+      await assertCalls([])
+    })
+  })
+
   describe('destroy (--remove)', () => {
     test('returns error if removing configuration files fails', async () => {
       await writeToTempDir(mockBinDir, 'rm', mockScriptReturningErrorCode)
@@ -215,6 +222,7 @@ describe('examnet (just port)', () => {
       await assertCalls([
         callSystemctl('disable', 'ytl-linux-digabi2-examnet', '--now'),
         callSystemctl('disable', 'dnsmasq', '--now'),
+        callSystemctl('disable', 'ytl-linux-digabi2-examnet-firewall.service', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.timer', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.service', '--now'),
         callRm(`${mockExamnetConfigDir}/server-own-ip`)
@@ -227,6 +235,7 @@ describe('examnet (just port)', () => {
       await assertCalls([
         callSystemctl('disable', 'ytl-linux-digabi2-examnet', '--now'),
         callSystemctl('disable', 'dnsmasq', '--now'),
+        callSystemctl('disable', 'ytl-linux-digabi2-examnet-firewall.service', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.timer', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.service', '--now'),
         callRm(`${mockExamnetConfigDir}/server-own-ip`),
@@ -263,6 +272,7 @@ describe('examnet (just port)', () => {
       await assertCalls([
         callSystemctl('disable', 'ytl-linux-digabi2-examnet', '--now'),
         callSystemctl('disable', 'dnsmasq', '--now'),
+        callSystemctl('disable', 'ytl-linux-digabi2-examnet-firewall.service', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.timer', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.service', '--now'),
         callRm(`${mockExamnetConfigDir}/server-own-ip`),
@@ -297,6 +307,7 @@ describe('examnet (just port)', () => {
       await assertCalls([
         callSystemctl('disable', 'ytl-linux-digabi2-examnet', '--now'),
         callSystemctl('disable', 'dnsmasq', '--now'),
+        callSystemctl('disable', 'ytl-linux-digabi2-examnet-firewall.service', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.timer', '--now'),
         callSystemctl('disable', 'ytl-linux-digabi2-examnet-discovery.service', '--now'),
         callRm(`${mockExamnetConfigDir}/server-own-ip`),
@@ -683,6 +694,7 @@ describe('examnet (just port)', () => {
         callSystemctl('restart', 'docker'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet'),
         callSystemctl('enable', 'dnsmasq'),
+        callSystemctl('enable', 'ytl-linux-digabi2-examnet-firewall.service'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet-discovery.service'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet-discovery.timer'),
         callSystemctl('restart', 'systemd-resolved'),
@@ -888,6 +900,7 @@ describe('examnet (just port)', () => {
         callSystemctl('restart', 'docker'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet'),
         callSystemctl('enable', 'dnsmasq'),
+        callSystemctl('enable', 'ytl-linux-digabi2-examnet-firewall.service'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet-discovery.service'),
         callSystemctl('enable', 'ytl-linux-digabi2-examnet-discovery.timer'),
         callSystemctl('restart', 'systemd-resolved'),

--- a/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
+++ b/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet
@@ -94,6 +94,9 @@ for arg in "$@"; do
     --discovery)
       recipe="discovery"
       ;;
+    --restore-internet-forwarding)
+      recipe="restore-internet-forwarding"
+      ;;
     --remove)
       recipe="destroy"
       ;;

--- a/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet-firewall.service
+++ b/packages/ytl-linux-digabi2-examnet/ytl-linux-digabi2-examnet-firewall.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Restore Digabi 2 examnet firewall rules
+After=NetworkManager.service ytl-linux-digabi2-wait-for-listen-ip.service docker.service
+Wants=NetworkManager.service ytl-linux-digabi2-wait-for-listen-ip.service docker.service
+ConditionPathExists=/etc/ytl-linux-digabi2-examnet/config/net-device-wan
+ConditionPathExists=/etc/ytl-linux-digabi2-examnet/config/net-device-lan
+ConditionPathExists=/etc/ytl-linux-digabi2-examnet/config/server-own-ip
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ytl-linux-digabi2-examnet --restore-internet-forwarding
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
- iptables rules for internet forwarding don't survive reboot, so they need to be recreated after boot
- Restoring is done by oneshot systemd service ytl-linux-digabi2-examnet-firewall.service