### PR TITLE
Add mechanism for restoring YTL-Linux root partition to clean install state

### DIFF
--- a/docs/autoinstall-config-24/user-data
+++ b/docs/autoinstall-config-24/user-data
@@ -210,12 +210,64 @@ autoinstall:
     - cinnamon-core
     - ytl-linux-customize-24
     - ytl-linux-purge-deb
+    - ytl-linux-recovery-tools
     - snapd
   snaps:
     - name: firefox
   storage:
-      layout:
-          name: direct
+      config:
+        - id: disk0
+          type: disk
+          match:
+            size: largest
+          ptable: gpt
+          wipe: superblock-recursive
+          grub_device: true
+        - id: partition-efi
+          type: partition
+          device: disk0
+          size: 512M
+          flag: boot
+        - id: format-efi
+          type: format
+          volume: partition-efi
+          fstype: fat32
+          label: YTL_EFI
+        - id: mount-efi
+          type: mount
+          device: format-efi
+          path: /boot/efi
+        - id: partition-recovery
+          type: partition
+          device: disk0
+          size: 2G
+        - id: format-recovery
+          type: format
+          volume: partition-recovery
+          fstype: ext4
+          label: YTL_RECOVERY
+        - id: partition-clean-install-storage
+          type: partition
+          device: disk0
+          size: 8G
+        - id: format-clean-install-storage
+          type: format
+          volume: partition-clean-install-storage
+          fstype: ext4
+          label: YTL_CLEAN_INSTALL
+        - id: partition-root
+          type: partition
+          device: disk0
+          size: -1
+        - id: format-root
+          type: format
+          volume: partition-root
+          fstype: ext4
+          label: YTL_ROOT
+        - id: mount-root
+          type: mount
+          device: format-root
+          path: /
   user-data:
       timezone: Europe/Helsinki
       users:
@@ -255,3 +307,10 @@ autoinstall:
     # Set hostname (cannot be set in identity section as we use user-data to create the user)
     # Tried using hostnamectl set-hostname, but it doesn't properly work in curtin for some unexplained reason, so good ol' echo it is
     - echo ktp > /target/etc/hostname
+    # Install tools into the installer environment for building the recovery partition and creating a root snapshot
+    - apt-get update
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y debootstrap fsarchiver
+    # Build the recovery Linux, add a GRUB recovery entry and create the post-install root snapshot
+    - /target/usr/local/sbin/ytl-linux-recovery-prepare --target /target --release noble --mirror http://mirrors.nic.funet.fi/ubuntu/
+    # Refresh grub once more so the newly installed recovery menu entry becomes bootable
+    - curtin in-target --target=/target -- update-grub

--- a/packages/ytl-linux-recovery-tools/Makefile
+++ b/packages/ytl-linux-recovery-tools/Makefile
@@ -1,0 +1,41 @@
+NAME := ytl-linux-recovery-tools
+VERSION := 0.1.0
+
+DEPENDENCIES := \
+	--depends bash \
+	--depends coreutils \
+	--depends e2fsprogs \
+	--depends fsarchiver \
+	--depends grub-efi-amd64-bin \
+	--depends python3 \
+	--depends rsync \
+	--depends util-linux
+
+DEB_ROOT := deb-root
+
+
+deb:
+	if [ -d $(DEB_ROOT) ]; then rm -fR $(DEB_ROOT)/; fi
+	if [ -f $(NAME)_$(VERSION)_amd64.deb ]; then rm $(NAME)_$(VERSION)_amd64.deb; fi
+
+	mkdir -p $(DEB_ROOT)/usr/local/sbin
+	cp bin/* $(DEB_ROOT)/usr/local/sbin/
+	chmod 755 $(DEB_ROOT)/usr/local/sbin/*
+
+	mkdir -p $(DEB_ROOT)/usr/local/lib/ytl-linux-recovery-tools
+	cp lib/* $(DEB_ROOT)/usr/local/lib/ytl-linux-recovery-tools/
+	chmod 644 $(DEB_ROOT)/usr/local/lib/ytl-linux-recovery-tools/*
+	chmod 755 $(DEB_ROOT)/usr/local/lib/ytl-linux-recovery-tools/*.sh
+
+	mkdir -p $(DEB_ROOT)/usr/local/share/doc/$(NAME)
+	cp README.md $(DEB_ROOT)/usr/local/share/doc/$(NAME)/
+
+	fpm -C $(DEB_ROOT)/ -s dir --name $(NAME) --architecture native -t deb --version "$(VERSION)" \
+		--description "Tools to build and restore YTL Linux recovery snapshots" \
+		--maintainer "abitti@ylioppilastutkinto.fi" \
+		--vendor "Matriculation Examination Board" \
+		--url "https://github.com/digabi/ytl-linux" \
+		$(DEPENDENCIES) \
+		.
+
+

--- a/packages/ytl-linux-recovery-tools/README.md
+++ b/packages/ytl-linux-recovery-tools/README.md
@@ -1,0 +1,5 @@
+# ytl-linux-recovery-tools
+
+Tools for preparing a recovery Linux partition, creating a post-install `fsarchiver` snapshot of the installed root 
+filesystem, and restoring the snapshot later from the recovery environment.
+

--- a/packages/ytl-linux-recovery-tools/bin/ytl-linux-recovery-prepare
+++ b/packages/ytl-linux-recovery-tools/bin/ytl-linux-recovery-prepare
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+exec /usr/local/lib/ytl-linux-recovery-tools/prepare-recovery.sh "$@"
+

--- a/packages/ytl-linux-recovery-tools/bin/ytl-linux-recovery-restore
+++ b/packages/ytl-linux-recovery-tools/bin/ytl-linux-recovery-restore
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+exec /usr/local/lib/ytl-linux-recovery-tools/restore-clean-install.sh "$@"
+

--- a/packages/ytl-linux-recovery-tools/lib/grub-recovery-menuentry.cfg
+++ b/packages/ytl-linux-recovery-tools/lib/grub-recovery-menuentry.cfg
@@ -1,0 +1,6 @@
+menuentry 'YTL Recovery' {
+    search --no-floppy --label --set=root YTL_RECOVERY
+    linux /boot/vmlinuz root=LABEL=YTL_RECOVERY ro quiet
+    initrd /boot/initrd.img
+}
+

--- a/packages/ytl-linux-recovery-tools/lib/prepare-recovery.sh
+++ b/packages/ytl-linux-recovery-tools/lib/prepare-recovery.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TARGET=""
+RELEASE="noble"
+MIRROR="http://archive.ubuntu.com/ubuntu/"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --release)
+      RELEASE="$2"
+      shift 2
+      ;;
+    --mirror)
+      MIRROR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  echo "Usage: $0 --target <target-root> [--release noble] [--mirror url]" >&2
+  exit 1
+fi
+
+TARGET=$(readlink -f "$TARGET")
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+RECOVERY_LABEL="YTL_RECOVERY"
+SNAPSHOT_LABEL="YTL_CLEAN_INSTALL"
+ROOT_LABEL="YTL_ROOT"
+EFI_LABEL="YTL_EFI"
+RECOVERY_MNT=/mnt/ytl-recovery
+SNAPSHOT_MNT=/mnt/ytl-clean-install
+ROOT_SNAPSHOT_NAME=rootfs-postinstall.fsa
+ROOT_SNAPSHOT_PATH="$SNAPSHOT_MNT/$ROOT_SNAPSHOT_NAME"
+RECOVERY_PACKAGES=(
+  linux-image-generic
+  systemd-sysv
+  grub-efi-amd64-bin
+  efibootmgr
+  fsarchiver
+  e2fsprogs
+  dosfstools
+  util-linux
+  bash
+  coreutils
+)
+
+log() {
+  echo "ytl-linux-recovery-tools: $*"
+}
+
+cleanup() {
+  set +e
+  if mountpoint -q "$RECOVERY_MNT/dev/pts"; then umount "$RECOVERY_MNT/dev/pts"; fi
+  if mountpoint -q "$RECOVERY_MNT/dev"; then umount "$RECOVERY_MNT/dev"; fi
+  if mountpoint -q "$RECOVERY_MNT/proc"; then umount "$RECOVERY_MNT/proc"; fi
+  if mountpoint -q "$RECOVERY_MNT/sys"; then umount "$RECOVERY_MNT/sys"; fi
+  if mountpoint -q "$RECOVERY_MNT"; then umount "$RECOVERY_MNT"; fi
+  if mountpoint -q "$SNAPSHOT_MNT"; then umount "$SNAPSHOT_MNT"; fi
+}
+trap cleanup EXIT
+
+mkdir -p "$RECOVERY_MNT" "$SNAPSHOT_MNT"
+
+RECOVERY_DEV=$(readlink -f "/dev/disk/by-label/$RECOVERY_LABEL")
+SNAPSHOT_DEV=$(readlink -f "/dev/disk/by-label/$SNAPSHOT_LABEL")
+ROOT_DEV=$(findmnt -n -o SOURCE "$TARGET")
+EFI_DEV=$(findmnt -n -o SOURCE "$TARGET/boot/efi")
+
+log "Recovery partition: $RECOVERY_DEV"
+log "Snapshot partition: $SNAPSHOT_DEV"
+log "Root filesystem: $ROOT_DEV"
+log "EFI filesystem: $EFI_DEV"
+
+mount "$RECOVERY_DEV" "$RECOVERY_MNT"
+mount "$SNAPSHOT_DEV" "$SNAPSHOT_MNT"
+
+log "Bootstrapping recovery system into $RECOVERY_MNT"
+debootstrap --arch amd64 --variant=minbase "$RELEASE" "$RECOVERY_MNT" "$MIRROR"
+
+mkdir -p "$RECOVERY_MNT/etc/apt"
+
+cat > "$RECOVERY_MNT/etc/apt/sources.list" <<EOF
+ deb $MIRROR $RELEASE main restricted universe multiverse
+ deb $MIRROR ${RELEASE}-updates main restricted universe multiverse
+ deb $MIRROR ${RELEASE}-security main restricted universe multiverse
+EOF
+
+mount --bind /dev "$RECOVERY_MNT/dev"
+mount --bind /dev/pts "$RECOVERY_MNT/dev/pts"
+mount --bind /proc "$RECOVERY_MNT/proc"
+mount --bind /sys "$RECOVERY_MNT/sys"
+
+chroot "$RECOVERY_MNT" apt-get update
+chroot "$RECOVERY_MNT" env DEBIAN_FRONTEND=noninteractive apt-get install -y "${RECOVERY_PACKAGES[@]}"
+
+cat > "$RECOVERY_MNT/etc/fstab" <<EOF
+LABEL=$RECOVERY_LABEL / ext4 defaults 0 1
+LABEL=$SNAPSHOT_LABEL /mnt/clean-install ext4 defaults 0 2
+LABEL=$EFI_LABEL /boot/efi vfat umask=0077 0 1
+EOF
+
+mkdir -p "$RECOVERY_MNT/mnt/clean-install"
+mkdir -p "$RECOVERY_MNT/boot/efi"
+mkdir -p "$RECOVERY_MNT/usr/local/sbin"
+echo ytl-recovery > "$RECOVERY_MNT/etc/hostname"
+cp "$SCRIPT_DIR/restore-clean-install.sh" "$RECOVERY_MNT/usr/local/sbin/ytl-restore-clean-install"
+chmod 755 "$RECOVERY_MNT/usr/local/sbin/ytl-restore-clean-install"
+
+cat > "$RECOVERY_MNT/root/README-restore.txt" <<EOF
+Run /usr/local/sbin/ytl-restore-clean-install to restore LABEL=$ROOT_LABEL from the post-install snapshot stored on LABEL=$SNAPSHOT_LABEL.
+EOF
+
+mkdir -p "$TARGET/etc/grub.d"
+cat > "$TARGET/etc/grub.d/41_ytl_recovery" <<'EOF'
+#!/bin/sh
+exec tail -n +3 "$0"
+EOF
+cat "$SCRIPT_DIR/grub-recovery-menuentry.cfg" >> "$TARGET/etc/grub.d/41_ytl_recovery"
+chmod 755 "$TARGET/etc/grub.d/41_ytl_recovery"
+
+log "Creating fsarchiver snapshot at $ROOT_SNAPSHOT_PATH"
+sync
+fsfreeze --freeze "$TARGET"
+archive_status=0
+if ! fsarchiver savefs "$ROOT_SNAPSHOT_PATH" "$ROOT_DEV"; then
+  archive_status=$?
+fi
+fsfreeze --unfreeze "$TARGET" || true
+if [[ $archive_status -ne 0 ]]; then
+  echo "fsarchiver savefs failed with exit code $archive_status" >&2
+  exit "$archive_status"
+fi
+sha256sum "$ROOT_SNAPSHOT_PATH" > "$ROOT_SNAPSHOT_PATH.sha256"
+cat > "$SNAPSHOT_MNT/rootfs-postinstall.meta" <<EOF
+ROOT_LABEL=$ROOT_LABEL
+RECOVERY_LABEL=$RECOVERY_LABEL
+SNAPSHOT_LABEL=$SNAPSHOT_LABEL
+EFI_LABEL=$EFI_LABEL
+ROOT_DEVICE=$ROOT_DEV
+EFI_DEVICE=$EFI_DEV
+CREATED_AT=$(date --iso-8601=seconds)
+ARCHIVE=$ROOT_SNAPSHOT_NAME
+EOF
+
+log "Recovery environment prepared and snapshot created successfully"
+
+

--- a/packages/ytl-linux-recovery-tools/lib/restore-clean-install.sh
+++ b/packages/ytl-linux-recovery-tools/lib/restore-clean-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_LABEL="${ROOT_LABEL:-YTL_ROOT}"
+SNAPSHOT_LABEL="${SNAPSHOT_LABEL:-YTL_CLEAN_INSTALL}"
+EFI_LABEL="${EFI_LABEL:-YTL_EFI}"
+ARCHIVE_NAME="${ARCHIVE_NAME:-rootfs-postinstall.fsa}"
+TARGET_MNT=/mnt/ytl-restore-target
+SNAPSHOT_MNT=/mnt/ytl-restore-snapshot
+EFI_MNT=$TARGET_MNT/boot/efi
+
+log() {
+  echo "ytl-linux-recovery-tools: $*"
+}
+
+cleanup() {
+  set +e
+  if mountpoint -q "$TARGET_MNT/sys"; then umount "$TARGET_MNT/sys"; fi
+  if mountpoint -q "$TARGET_MNT/proc"; then umount "$TARGET_MNT/proc"; fi
+  if mountpoint -q "$TARGET_MNT/dev"; then umount "$TARGET_MNT/dev"; fi
+  if mountpoint -q "$EFI_MNT"; then umount "$EFI_MNT"; fi
+  if mountpoint -q "$TARGET_MNT"; then umount "$TARGET_MNT"; fi
+  if mountpoint -q "$SNAPSHOT_MNT"; then umount "$SNAPSHOT_MNT"; fi
+}
+trap cleanup EXIT
+
+ROOT_DEV=$(readlink -f "/dev/disk/by-label/$ROOT_LABEL")
+SNAPSHOT_DEV=$(readlink -f "/dev/disk/by-label/$SNAPSHOT_LABEL")
+EFI_DEV=$(readlink -f "/dev/disk/by-label/$EFI_LABEL")
+
+mkdir -p "$TARGET_MNT" "$SNAPSHOT_MNT"
+mount "$SNAPSHOT_DEV" "$SNAPSHOT_MNT"
+
+if [[ ! -f "$SNAPSHOT_MNT/$ARCHIVE_NAME" ]]; then
+  echo "Snapshot archive $ARCHIVE_NAME not found on $SNAPSHOT_DEV" >&2
+  exit 1
+fi
+if [[ -f "$SNAPSHOT_MNT/$ARCHIVE_NAME.sha256" ]]; then
+  (cd "$SNAPSHOT_MNT" && sha256sum -c "$ARCHIVE_NAME.sha256")
+fi
+
+log "Restoring $ROOT_DEV from $SNAPSHOT_MNT/$ARCHIVE_NAME"
+mkfs.ext4 -F -L "$ROOT_LABEL" "$ROOT_DEV"
+fsarchiver restfs "$SNAPSHOT_MNT/$ARCHIVE_NAME" id=0,dest="$ROOT_DEV"
+
+mount "$ROOT_DEV" "$TARGET_MNT"
+mkdir -p "$EFI_MNT"
+mount "$EFI_DEV" "$EFI_MNT"
+mkdir -p "$TARGET_MNT/dev" "$TARGET_MNT/proc" "$TARGET_MNT/sys"
+
+if [[ -f "$TARGET_MNT/etc/fstab" ]]; then
+  sed -i \
+    -e "s|^[^#].* / .*|LABEL=$ROOT_LABEL / ext4 defaults 0 1|" \
+    -e "s|^[^#].* /boot/efi .*|LABEL=$EFI_LABEL /boot/efi vfat umask=0077 0 1|" \
+    "$TARGET_MNT/etc/fstab"
+fi
+
+mount --bind /dev "$TARGET_MNT/dev"
+mount --bind /proc "$TARGET_MNT/proc"
+mount --bind /sys "$TARGET_MNT/sys"
+
+chroot "$TARGET_MNT" update-initramfs -u
+chroot "$TARGET_MNT" update-grub
+log "Restore completed successfully. Reboot when ready."
+
+


### PR DESCRIPTION
- New partition YTL_CLEAN_INSTALL contains contents of the root partition created with fsarchiver
- New partition YTL_RECOVERY contains a minimal Linux that can be booted to restore the root partition with fsarchiver