### PR TITLE
Add cups-dummy

### DIFF
--- a/packages/ytl-linux-cups-dummy/Makefile
+++ b/packages/ytl-linux-cups-dummy/Makefile
@@ -2,6 +2,8 @@ NAME := ytl-linux-cups-dummy
 VERSION := 0.1
 
 DEPENDENCIES := --depends cinnamon-common --depends bash
+CONFLICTS := --conflicts cups-client --conflicts cups-bsd --conflicts lpr --conflicts lprng
+REPLACES := --replaces cups-client --replaces cups-bsd --replaces lpr --replaces lprng
 
 deb:
 	if [ -d deb-root ]; then rm -fR deb-root/; fi
@@ -28,4 +30,6 @@ deb:
 		 --url "https://github.com/digabi/ytl-linux" \
 		 --deb-no-default-config-files \
 		 $(DEPENDENCIES) \
+		 $(CONFLICTS) \
+		 $(REPLACES) \
 		.

--- a/packages/ytl-linux-cups-dummy/Makefile
+++ b/packages/ytl-linux-cups-dummy/Makefile
@@ -1,0 +1,31 @@
+NAME := ytl-linux-cups-dummy
+VERSION := 0.1
+
+DEPENDENCIES := --depends cinnamon-common --depends bash
+
+deb:
+	if [ -d deb-root ]; then rm -fR deb-root/; fi
+	if [ -d deb-scripts ]; then rm -fR deb-scripts/; fi
+	if [ -f $(NAME)_$(VERSION)_all.deb ]; then rm $(NAME)_$(VERSION)_all.deb; fi
+
+	# Copy scripts
+	mkdir -p deb-root/usr/bin/
+
+	cp lpq deb-root/usr/bin/
+	chmod 755 deb-root/usr/bin/lpq
+
+	cp lpstat deb-root/usr/bin/
+	chmod 755 deb-root/usr/bin/lpstat
+
+	# Package documentation
+	mkdir -p deb-root/usr/local/share/doc/$(NAME)
+	cp *.md deb-root/usr/local/share/doc/$(NAME)/
+
+	fpm -C deb-root/ -s dir --name "$(NAME)" --architecture all -t deb --version "$(VERSION)" \
+		 --description "A dummy version of lpstat and lpq to fool Cinnamon" \
+		 --maintainer "abitti@ylioppilastutkinto.fi" \
+		 --vendor "Matriculation Examination Board" \
+		 --url "https://github.com/digabi/ytl-linux" \
+		 --deb-no-default-config-files \
+		 $(DEPENDENCIES) \
+		.

--- a/packages/ytl-linux-cups-dummy/README.md
+++ b/packages/ytl-linux-cups-dummy/README.md
@@ -1,0 +1,13 @@
+# cups-dummy
+
+This package provides dummy `lpq` and `lpstat` binaries so that the Cinnamon DE's [`printers@cinnamon` applet](https://github.com/linuxmint/cinnamon/tree/6.0.4/files/usr/share/cinnamon/applets/printers%40cinnamon.org) is happy with us and doesn't crash, leading to "Sorry, Ubuntu 24.04 has experienced an internal error."
+
+## What our lpstat needs to do
+
+- Return exit code 1 with lpstat -a (can contain text or not)
+- Not include a ': ' string with lpstat -d (can say "no system default destination" or not)
+- Return '' with lpstat -l
+- Return '' with lpstat -o
+
+## What our lpq needs to do
+- Return 'no entries' with lpq -a

--- a/packages/ytl-linux-cups-dummy/lpq
+++ b/packages/ytl-linux-cups-dummy/lpq
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'no entries'

--- a/packages/ytl-linux-cups-dummy/lpstat
+++ b/packages/ytl-linux-cups-dummy/lpstat
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+case $1 in
+
+    -a)
+        exit 1
+        ;;
+    
+    -d)
+        echo 'no system default destination'
+        ;;
+
+    *)
+        echo
+        ;;
+esac
+
+exit 0

--- a/packages/ytl-linux-customize-24/Makefile
+++ b/packages/ytl-linux-customize-24/Makefile
@@ -3,7 +3,7 @@ VERSION := 1.4.0
 # Dependencies which are not related to any code in the
 DEPENDENCIES_META := --depends ethtool --depends exfat-fuse --depends update-manager --depends gnome-icon-theme \
 	--depends dconf-cli --depends ytl-linux-cpu-governor --depends ytl-linux-digabi1-examnet --depends ytl-linux-digabi2 --depends ytl-linux-digabi2-examnet \
-	--depends anydesk-meb --depends ytl-linux-tasks --depends ytl-linux-sysmon --depends ytl-linux-digabi2-diagnostics
+	--depends anydesk-meb --depends ytl-linux-tasks --depends ytl-linux-sysmon --depends ytl-linux-digabi2-diagnostics --depends ytl-linux-cups-dummy
 RECOMMENDS_META := --deb-recommends digabi-usb-monster
 
 DEPENDENCIES_YTL-GRUB-SAFE-GRAPHICS := --depends policykit-1


### PR DESCRIPTION
Adds a dummy version of `lpstat` and `lpq` to satisfy Cinnamon's `printers@cinnamon` -applet. The applet currently crashes because it [expects cups to be installed](https://github.com/linuxmint/cinnamon/tree/6.0.4/files/usr/share/cinnamon/applets/printers%40cinnamon.org), leading to errors:
<img width="968" height="290" alt="image" src="https://github.com/user-attachments/assets/559489aa-3f79-4551-9b8a-0caf05755cf5" />

[Slack thread](https://yotutkinto.slack.com/archives/C05MSCD693P/p1777986792533009?thread_ts=1777898394.681569&cid=C05MSCD693P) about the issue.

## Process

I read through the code of `printers@cinnamon` and arrived at this list of requirements:

### What our lpstat needs to do

- Return exit code 1 with `lpstat -a` (can contain text or not)
- Not include a `: ` string with `lpstat -d` (can say "no system default destination" or not)
- Return '' with `lpstat -l`
- Return '' with `lpstat -o`

### What our lpq needs to do
- Return `no entries` with `lpq -a`

This satisfies the applet since we look like a system with no printers installed and no jobs running.