### PR TITLE
Feature/Run autoremove on successful automatic upgrades

### DIFF
--- a/docs/autoinstall-config-24/user-data
+++ b/docs/autoinstall-config-24/user-data
@@ -250,6 +250,8 @@ autoinstall:
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
     - sed -i 's/APT::Periodic::Unattended-Upgrade .*/APT::Periodic::Unattended-Upgrade "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
+    # Keep last two kernels on autoremove
+    - echo 'APT::NeverAutoRemove::KernelCount "2";' >/target/etc/apt/apt.conf.d/99kernel-retention
     # Disable prompt for upgrading to newer versions
     - sed -i 's/^Prompt=.*/Prompt=never/' /target/etc/update-manager/release-upgrades
     # Set hostname (cannot be set in identity section as we use user-data to create the user)

--- a/packages/ytl-linux-update-checker/Makefile
+++ b/packages/ytl-linux-update-checker/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-update-checker
-VERSION := 0.4.2
+VERSION := 0.5.0
 
 DEPENDENCIES := --depends python3-systemd --depends python3-gi --depends python3-gi-cairo --depends gir1.2-gtk-3.0
 DEB_ROOT := deb-root

--- a/packages/ytl-linux-update-checker/ytl-linux-software-update
+++ b/packages/ytl-linux-update-checker/ytl-linux-software-update
@@ -39,5 +39,11 @@ if ! DEBIAN_FRONTEND=noninteractive apt-get -y upgrade | log; then
   exit 1
 fi
 
+echo 'APT::NeverAutoRemove::KernelCount "2";' >/etc/apt/apt.conf.d/99kernel-retention
+
+if ! DEBIAN_FRONTEND=noninteractive apt-get autoremove -y | log; then
+  log "apt-get autoremove failed"
+fi
+
 log "Software update succeeded"
 exit 0


### PR DESCRIPTION
The new `ytl-linux-update-checker` currently leaves packages on the system that could be autoremoved. This causes the stock Ubuntu update dialog to appear and ask the user to authorize autoremoval. Let's do it ourselves so that the user never sees the Ubuntu update dialog. But, for disaster recovery we set `KernelCount=2` so that we keep the current _and previous_ kernel version.

# Testing

Tested to work locally in VM image, but team decided not to implement for now, since autoremoves could break something and is not currently covered by testing.