### PR TITLE
Fix update checker after install script crashing new installs

### DIFF
--- a/packages/ytl-linux-update-checker/Makefile
+++ b/packages/ytl-linux-update-checker/Makefile
@@ -1,5 +1,5 @@
 NAME := ytl-linux-update-checker
-VERSION := 0.4.2
+VERSION := 0.4.3
 
 DEPENDENCIES := --depends python3-systemd --depends python3-gi --depends python3-gi-cairo --depends gir1.2-gtk-3.0
 DEB_ROOT := deb-root

--- a/packages/ytl-linux-update-checker/after-install.sh
+++ b/packages/ytl-linux-update-checker/after-install.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 systemctl daemon-reload
 
-systemctl enable --now ytl-linux-update-check.timer
+systemctl enable ytl-linux-update-check.timer


### PR DESCRIPTION
Postinstall-skripteissä ei voi ajaa `systemctl enable --now`, koska ensimmäisellä asennuksella ei olla missään oikeassa sessiossa vaan autoinstallissa; pitää jättää seuraavalle bootille