### PR TITLE
Fix install conflicts

### DIFF
--- a/packages/ytl-linux-digabi2-examnet/Makefile
+++ b/packages/ytl-linux-digabi2-examnet/Makefile
@@ -12,6 +12,9 @@ DEPENDENCIES := \
 	--depends jq \
 	--depends network-manager
 
+CONFLICTS := \
+	--conflicts systemd-timesyncd
+
 deb:
 	# Script files
 	mkdir -p deb-root/usr/local/sbin/
@@ -76,3 +79,4 @@ deb:
 		--after-install after-install.sh \
 		--before-remove before-remove.sh \
 		$(DEPENDENCIES)
+		$(CONFLICTS)

--- a/packages/ytl-linux-grub-safe-graphics/Makefile
+++ b/packages/ytl-linux-grub-safe-graphics/Makefile
@@ -20,4 +20,5 @@ deb:
 	cp ytl-grub-safe-graphics.png deb-root/usr/local/share/pixmaps/
 
 	ytl-fpm \
+		--before-install before-install.sh \
 	  $(DEPENDENCIES)

--- a/packages/ytl-linux-grub-safe-graphics/before-install.sh
+++ b/packages/ytl-linux-grub-safe-graphics/before-install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Remove old versions distributed Trojan horse style inside ytl-linux-customize-24 to prevent dpkg conflicts
+OLD_FILES_TO_REMOVE=(
+  /usr/local/share/pixmaps/ytl-grub-safe-graphics.png
+  /usr/share/applications/ytl-grub-safe-graphics-on.desktop
+  /usr/share/applications/ytl-grub-safe-graphics-off.desktop
+  /usr/share/polkit-1/actions/ytl-grub-safe-graphics.policy
+  /usr/local/sbin/ytl-grub-safe-graphics
+)
+
+for file in "${OLD_FILES_TO_REMOVE[@]}"; do
+  if [[ -f "$file" ]]; then
+    rm -f "$file"
+  fi
+done


### PR DESCRIPTION
Tässä korjataan kaksi eri ongelmaa, jotka ovat ilmentyneet tänään:

1. YTL-Linux ei asennu, koska `systemd-timesyncd` ja `chrony` menevät konfliktiin. Interaktiivisessa sessiossa tämä korjaantuu itsestään, mutta ilmeisesti tuoreessa asennuksessa ei suostuta resolveamaan sitä itse, joten koetetaan ohjata apt olemaan asentamatta sitä
2. Kun lakattiin kuljettamasta `ytl-grub-safe-graphics`:ia Troijanhevostyylillä `ytl-linux-customize-24`:n sisällä, kävikin niin, että `apt upgrade`:n aikana yritetään ylikirjoittaa vanhoja tiedostoja, jotka omistaa toinen paketti. Poistetaan ne ennen asennusta, jotta ei tule sotkua