### PR TITLE
Remove update-manager to prevent excessive popups

### DIFF
--- a/docs/autoinstall-config-24/user-data
+++ b/docs/autoinstall-config-24/user-data
@@ -251,8 +251,6 @@ autoinstall:
     # Disable automatic updates
     - sed -i 's/APT::Periodic::Update-Package-Lists .*/APT::Periodic::Update-Package-Lists "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
     - sed -i 's/APT::Periodic::Unattended-Upgrade .*/APT::Periodic::Unattended-Upgrade "0";/' /target/etc/apt/apt.conf.d/20auto-upgrades
-    # Disable prompt for upgrading to newer versions
-    - sed -i 's/^Prompt=.*/Prompt=never/' /target/etc/update-manager/release-upgrades
     # Set hostname (cannot be set in identity section as we use user-data to create the user)
     # Tried using hostnamectl set-hostname, but it doesn't properly work in curtin for some unexplained reason, so good ol' echo it is
     - echo ktp > /target/etc/hostname

--- a/packages/ytl-linux-customize-24/Makefile
+++ b/packages/ytl-linux-customize-24/Makefile
@@ -1,11 +1,10 @@
 export NAME := ytl-linux-customize-24
 export DESCRIPTION := "YTL Linux specific customisations for Ubuntu 24.04"
-export VERSION := 2.0.0
+export VERSION := 2.0.1
 
 DEPENDENCIES := \
 	--depends ethtool \
 	--depends exfat-fuse \
-	--depends update-manager \
 	--depends gnome-icon-theme \
 	--depends dconf-cli \
 	--depends gnome-screenshot \
@@ -22,6 +21,8 @@ DEPENDENCIES := \
 	--depends ytl-linux-system-reset
 
 RECOMMENDS := --deb-recommends digabi-usb-monster
+
+CONFLICTS := --conflicts update-manager
 
 deb:
 	# Qogir icons
@@ -44,4 +45,5 @@ deb:
 		--after-install after-install.sh \
 		--after-remove after-remove.sh \
 		$(DEPENDENCIES) \
-		$(RECOMMENDS)
+		$(RECOMMENDS) \
+		$(CONFLICTS)

--- a/packages/ytl-linux-purge-deb/Makefile
+++ b/packages/ytl-linux-purge-deb/Makefile
@@ -1,6 +1,6 @@
 export NAME := ytl-linux-purge-deb
 export DESCRIPTION := "Metapackage to remove obsolete deb packages installed by Ubuntu Autoinstall"
-export VERSION := 0.0.4
+export VERSION := 0.0.5
 
 CONFLICTS := \
 	--conflicts open-iscsi \
@@ -15,7 +15,8 @@ CONFLICTS := \
 	--conflicts cups-ipp-utils \
 	--conflicts cups-pdf \
 	--conflicts cups-ppdc \
-	--conflicts cups-server-common
+	--conflicts cups-server-common \
+	--conflicts update-manager
 
 deb:
 	ytl-fpm \


### PR DESCRIPTION
#128:ssä lisättiin meidän oma päivityksentarkistussysteemi YTL-Linuxiin. Se ajelee `apt update`:a taustalla. Tämä tosin nyt johtaa siihen, että Ubuntun oma Update Manager ponnauttelee ikkunoita saatavilla olevista päivityksistä alvariinsa. Meidän oma päivitysvekottimemme yrittää juurikin välttää tätä ja ponnauttaa ikkunan vain, kun YTL-Linuxiin on saatavilla päivityksiä, joten tämä on perin ärsyttävää.

Poistetaan siis Update Manager YTL-Linuxista. Tehty conflicts-lausekkeella sekä customizeen että purge-debiin, koska purge-deb ajetaan vain tuoreasennuksen yhteydessä.