### PR TITLE
Remove update-manager more thoroughly to prevent broken apt state

### DIFF
--- a/packages/ytl-linux-customize-24/Makefile
+++ b/packages/ytl-linux-customize-24/Makefile
@@ -1,6 +1,6 @@
 export NAME := ytl-linux-customize-24
 export DESCRIPTION := "YTL Linux specific customisations for Ubuntu 24.04"
-export VERSION := 2.0.1
+export VERSION := 2.0.2
 
 DEPENDENCIES := \
 	--depends ethtool \
@@ -21,8 +21,6 @@ DEPENDENCIES := \
 	--depends ytl-linux-system-reset
 
 RECOMMENDS := --deb-recommends digabi-usb-monster
-
-CONFLICTS := --conflicts update-manager
 
 deb:
 	# Qogir icons
@@ -45,5 +43,4 @@ deb:
 		--after-install after-install.sh \
 		--after-remove after-remove.sh \
 		$(DEPENDENCIES) \
-		$(RECOMMENDS) \
-		$(CONFLICTS)
+		$(RECOMMENDS)

--- a/packages/ytl-linux-purge-deb/Makefile
+++ b/packages/ytl-linux-purge-deb/Makefile
@@ -1,6 +1,6 @@
 export NAME := ytl-linux-purge-deb
 export DESCRIPTION := "Metapackage to remove obsolete deb packages installed by Ubuntu Autoinstall"
-export VERSION := 0.0.5
+export VERSION := 0.0.6
 
 CONFLICTS := \
 	--conflicts open-iscsi \
@@ -16,7 +16,9 @@ CONFLICTS := \
 	--conflicts cups-pdf \
 	--conflicts cups-ppdc \
 	--conflicts cups-server-common \
-	--conflicts update-manager
+	--conflicts update-manager \
+	--conflicts update-notifier \
+	--conflicts ubuntu-release-upgrader-gtk
 
 deb:
 	ytl-fpm \


### PR DESCRIPTION
#147 ei ollut ihan vielä tarpeeksi huolellinen - jos update-managerin poistaa, saattaa jäädä rikkinäinen APT-tila olemassa olevilla asennuksilla, missä `update-notifier` ja `ubuntu-release-upgrader-gtk` ovat asennettuja ja haluavat `update-manager`:n, mutta sitä ei saa enää asentaa.

Poistettu samalla conflicts-lauseke customizesta, koska purge-deb päivittyy myös järjestelmän mukana.