### PR TITLE
Remove systemd-timesync and update-manager through maintenance tasks

### DIFF
--- a/packages/ytl-linux-tasks/Makefile
+++ b/packages/ytl-linux-tasks/Makefile
@@ -1,6 +1,6 @@
 export NAME := ytl-linux-tasks
 export DESCRIPTION := "Command runner specialized for YTL Linux administration tasks"
-export VERSION := 0.5.0
+export VERSION := 0.6.0
 
 deb:
 	# Install a more up-to-date version of just than is available in the Ubuntu repos

--- a/packages/ytl-linux-tasks/justfile
+++ b/packages/ytl-linux-tasks/justfile
@@ -7,7 +7,7 @@ default:
 
 # A group of tasks essential for every healthy YTL Linux installation.
 [private]
-maintenance: migrate-package-keys remove-virtualbox
+maintenance: migrate-package-keys remove-virtualbox remove-systemd-timesyncd-and-update-manager
 
 # Installs public keys of package sources to supported location
 migrate-package-keys:
@@ -16,6 +16,10 @@ migrate-package-keys:
 # Remove VirtualBox 7.1 and its requirements (autopurge)
 remove-virtualbox:
     './scripts/2026-04-16_remove-virtualbox.sh'
+
+# Remove systemd-timesyncd and update-manager from existing installation
+remove-systemd-timesyncd-and-update-manager:
+    './scripts/2026-08-11_remove-systemd-timesyncd-and-update-manager.sh'
 
 # Creates a tarball of the Abitti 2 server database for e.g. troubleshooting or debugging
 archive-digabi2-database:

--- a/packages/ytl-linux-tasks/scripts/2026-08-11_remove-systemd-timesyncd-and-update-manager.sh
+++ b/packages/ytl-linux-tasks/scripts/2026-08-11_remove-systemd-timesyncd-and-update-manager.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+PACKAGES_TO_REMOVE=("systemd-timesyncd" "update-manager" "update-notifier" "ubuntu-release-upgrader-gtk")
+
+for package in "${PACKAGES_TO_REMOVE[@]}"; do
+    if dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then
+        echo "Removing $package..."
+        apt-get --yes remove "$package"
+        apt-get --yes autoremove
+        echo "$package removed."
+    fi
+done


### PR DESCRIPTION
#149 ei nyt ihan riittänyt vieläkään, vaan olemassaolevat asennukset voivat yhä jäädä solmuun. Poistetaan siis ongelmalliset paketit maintenance-taskilla.